### PR TITLE
Hide lab numbers from both lab cards and left navigation

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -844,6 +844,12 @@ body {
     box-shadow: 0 6px 16px rgba(0,120,212,0.5);
 }
 
+/* HIDE LAB NUMBERS - Remove numbering from both lab cards and sidebar navigation */
+.lab-sequence,
+.lab-order {
+    display: none !important;
+}
+
 /* Legacy support for .lab-number if still used anywhere */
 .lab-number {
     position: absolute;


### PR DESCRIPTION
- Added CSS rule to hide .lab-sequence elements (circular numbered badges on lab cards)
- Added CSS rule to hide .lab-order elements (small circular numbers in left sidebar)
- Numbers are completely hidden from view while maintaining all other functionality
- Changes apply to both Rich and Minimal themes