### PR TITLE
fix: Resolve apostrophe spacing issues in HTML rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,13 +4,20 @@ description: "Hands-on labs for building AI agents with Microsoft Copilot Studio
 baseurl: "/mcs-labs"
 url: "https://pratapladhani.github.io"
 
-# Build settings
+# Build settings  
 markdown: kramdown
 highlighter: rouge
 plugins:
   - jekyll-feed
   - jekyll-sitemap
   - jekyll-seo-tag
+
+# Kramdown settings to fix apostrophe spacing issues
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+  entity_output: numeric
+  smart_quotes: "&#x2019;,&#x2019;,&#x201C;,&#x201D;"
 
 # Development settings for better file watching
 livereload: true


### PR DESCRIPTION
Bug Fix: Resolves spacing issues after apostrophes in lab content. Root cause was smart quotes in markdown being rendered inconsistently by Kramdown. Solution: Configure Kramdown to use proper HTML entities for consistent rendering. Zero content changes - pure Jekyll configuration fix.