### PR TITLE
docs: add PR merge verification step to workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -59,6 +59,21 @@ This document contains essential context for GitHub Copilot when working on the 
    Remove-Item pr-body.md
    ```
 
+6. **PR Merge Verification**: ALWAYS verify PR is merged before branch cleanup
+
+   - **STOP if**: User wants to delete feature branch or switch away
+   - **Action**: Ask "Has the PR been merged to upstream? Let me verify first."
+   - **Verification**: Check PR status before any cleanup operations
+   - **Why**: Prevents accidental loss of work if PR hasn't been merged yet
+   - **Safe to delete**: Only after confirming PR is merged to upstream/main
+
+   ```powershell
+   # Verify PR status before cleanup
+   gh pr view <PR-number> --repo microsoft/mcs-labs
+
+   # Only proceed with cleanup if status shows "MERGED"
+   ```
+
 ### Quality Gates - Enforce Before Commit
 
 **Documentation Updates (REQUIRED for big features):**
@@ -105,6 +120,7 @@ This document contains essential context for GitHub Copilot when working on the 
 - ❌ **Code without adequate comments for collaborators - STOP and add them first**
 - ❌ **UI changes without CSS verification - STOP and check all CSS files first**
 - ❌ Committing without asking about documentation/comments
+- ❌ **Deleting feature branch before PR is merged - STOP and verify PR status first**
 
 **CRITICAL: Before ANY git commit command:**
 


### PR DESCRIPTION
## Summary
Adds a critical safeguard to the development workflow to prevent accidental branch deletion before PR merge.

## Changes

### Workflow Enhancement: PR Merge Verification (Step 6)
- ✅ Added mandatory verification step before branch cleanup
- ✅ Requires checking PR merge status using gh pr view
- ✅ Prevents accidental loss of work from premature branch deletion
- ✅ Added to BLOCKING Actions list in assistant guidelines

## Problem Solved
This addresses the scenario where a feature branch is accidentally deleted before the PR is merged to upstream, resulting in lost work. The new workflow step ensures that GitHub Copilot will:

1. **Stop the user** if they try to delete a feature branch
2. **Verify PR status** using GitHub CLI before allowing cleanup
3. **Only proceed** after confirming the PR shows "MERGED" status

## Workflow Changes

**Before:**
1. Create feature branch
2. Make changes & test
3. Push to origin
4. Merge to local main
5. Create PR
6. ~~Delete branch~~ ❌ (could happen before merge!)

**After:**
1. Create feature branch
2. Make changes & test
3. Push to origin
4. Merge to local main
5. Create PR
6. **✅ VERIFY PR IS MERGED** ← New mandatory step
7. Delete branch (only if verified)

## Impact
- Prevents data loss from premature branch deletion
- Enforces best practices in Git workflow
- Improves safety for all future contributions

## Testing
- N/A - Documentation only change
- This workflow will be enforced by GitHub Copilot going forward

## Checklist
- [x] Workflow documentation updated
- [x] BLOCKING Actions list updated
- [x] Clear verification command provided
- [x] Rationale explained
