### PR TITLE
feat: Switch Azure AI Workshop lab order for better learning flow

### DIFF
--- a/_data/lab-config.yml
+++ b/_data/lab-config.yml
@@ -368,11 +368,11 @@ azure_ai_workshop_lab_orders:
   # Lab 3: BYOM Tool in Studio (40 min)
   3: "mcs-byom" # Bring Your Own Model capabilities in Copilot Studio
 
-  # Lab 4: Extend with MCP Server (70 min)
-  4: "guildhall-custom-mcp" # Build and deploy custom MCP server for extensibility
+  # Lab 4: Data Fabric Agent (45 min)
+  4: "data-fabric-agent" # Fabric Data Agents with Agent-to-Agent communication
 
-  # Lab 5: Data Fabric Agent (45 min)
-  5: "data-fabric-agent" # Fabric Data Agents with Agent-to-Agent communication
+  # Lab 5: Extend with MCP Server (70 min)
+  5: "guildhall-custom-mcp" # Build and deploy custom MCP server for extensibility
 
 # =====================================================
 # MCS IN A DAY EVENT LAB ORDERING - Specific sequence for MCS in a Day workshop

--- a/lab-config.yml
+++ b/lab-config.yml
@@ -368,11 +368,11 @@ azure_ai_workshop_lab_orders:
   # Lab 3: BYOM Tool in Studio (40 min)
   3: "mcs-byom" # Bring Your Own Model capabilities in Copilot Studio
 
-  # Lab 4: Extend with MCP Server (70 min)
-  4: "guildhall-custom-mcp" # Build and deploy custom MCP server for extensibility
+  # Lab 4: Data Fabric Agent (45 min)
+  4: "data-fabric-agent" # Fabric Data Agents with Agent-to-Agent communication
 
-  # Lab 5: Data Fabric Agent (45 min)
-  5: "data-fabric-agent" # Fabric Data Agents with Agent-to-Agent communication
+  # Lab 5: Extend with MCP Server (70 min)
+  5: "guildhall-custom-mcp" # Build and deploy custom MCP server for extensibility
 
 # =====================================================
 # MCS IN A DAY EVENT LAB ORDERING - Specific sequence for MCS in a Day workshop


### PR DESCRIPTION
## Description

Switches the order of Labs 4 and 5 in the Azure AI Workshop event to improve the learning flow.

## Changes

- **Lab 4**: Now "Data Fabric Agent" (45 min) - previously Lab 5
- **Lab 5**: Now "Build and deploy custom MCP server (Guild Hall)" (70 min) - previously Lab 4

## Rationale

This reordering provides a better pedagogical progression by introducing the Data Fabric Agent concepts before diving into the more complex custom MCP server implementation.

## Testing

- [x] Local testing completed
- [x] Jekyll rebuild verified
- [x] Azure AI Workshop page displays correct lab order
- [x] Lab navigation tested

## Files Changed

- `lab-config.yml` - Updated `azure_ai_workshop_lab_orders` section
- `_data/lab-config.yml` - Auto-synced copy updated
