### PR TITLE
fix: Remove broken image reference and update Azure region

### DIFF
--- a/labs/contract-alerts-azure-ai/README.md
+++ b/labs/contract-alerts-azure-ai/README.md
@@ -462,7 +462,7 @@ By the end of this module, your copilot will be able to **listen and understand 
 - **Connection name:** `SpeechtoTextConnection`
 - **Auth. Type:** `API Key`
 - **Account Key:** `[Provided in LAB Environment]`
-- **Region:** `westus`
+- **Region:** `eastus`
 
 ![Azure Speech Service connection configuration with connection name, API Key authentication, account key, and region fields](images/2c4.png)
 

--- a/labs/dataverse-mcp-connector/README.md
+++ b/labs/dataverse-mcp-connector/README.md
@@ -290,7 +290,6 @@ In this section, you'll learn how to create custom prompts that structure agent 
 21. Let's execute this prompt to get information on an account. Type `Show Account Details for Fourth Coffee`.
 
     ![Execute prompt with MCP enabled](images/step17a2-execute-prompts.png)
-    ![alt text](image.png)
 
     > [!TIP]
     > More information: [Use prompts to make your agent perform specific tasks - Microsoft Copilot Studio | Microsoft Learn](https://learn.microsoft.com/en-us/microsoft-copilot-studio/prompts)


### PR DESCRIPTION
## Description

Fixes two issues discovered during lab processing:
1. Broken image reference in dataverse-mcp-connector lab
2. Outdated Azure region in contract-alerts-azure-ai lab

## Changes

### Dataverse MCP Connector Lab
- **Issue**: Duplicate/broken image reference `![alt text](image.png)` causing PDF generation warning
- **Fix**: Removed the broken line (correct image `step17a2-execute-prompts.png` was already present)
- **Impact**: Resolves "Could not fetch resource image.png" warning during PDF generation

### Contract Alerts Azure AI Lab
- **Issue**: Azure Speech Service region set to `westus` 
- **Fix**: Updated region to `eastus` to align with current Azure deployment
- **Impact**: Ensures lab instructions match actual Azure resource configuration

## Rationale

These are minor but important fixes that improve the lab quality:
- The broken image reference was causing PDF generation warnings
- The region update ensures students can successfully complete the lab with current Azure resources

## Testing

- [x] Lab generation script runs without warnings
- [x] Both labs load correctly in Jekyll
- [x] Markdown formatting validated
- [x] No other image references broken

## Files Changed

- `labs/dataverse-mcp-connector/README.md` - Removed broken image reference
- `labs/contract-alerts-azure-ai/README.md` - Updated Azure region from westus to eastus
