### PR TITLE
fix: preserve leading dash in TOC anchors for emoji headings

### DIFF
--- a/scripts/Generate-Labs.ps1
+++ b/scripts/Generate-Labs.ps1
@@ -1442,11 +1442,13 @@ function Normalize-TOCMarkers {
             # Generate anchor (lowercase, replace spaces/special chars with hyphens)
             # WHY: Matches GitHub/Jekyll automatic anchor generation algorithm
             # IMPORTANT: Must match Jekyll's anchor generation to prevent broken links
-            $anchor = $headingText -replace '[^\w\s-]', ''  # Remove special chars except spaces and hyphens
-            $anchor = $anchor -replace '\s+', '-'            # Replace spaces with hyphens
-            $anchor = $anchor.ToLower()                      # Lowercase
-            $anchor = $anchor -replace '-+', '-'             # Collapse multiple hyphens
-            $anchor = $anchor.Trim('-')                      # Remove leading/trailing hyphens
+            # NOTE: Emojis are converted to dashes to match Jekyll's behavior
+            $anchor = $headingText -replace '[\p{So}\p{Sk}]', '-'  # Replace emojis/symbols with dash
+            $anchor = $anchor -replace '[^\w\s-]', ''               # Remove other special chars except spaces and hyphens
+            $anchor = $anchor -replace '\s+', '-'                   # Replace spaces with hyphens
+            $anchor = $anchor.ToLower()                             # Lowercase
+            $anchor = $anchor -replace '-+', '-'                    # Collapse multiple hyphens
+            $anchor = $anchor.TrimEnd('-')                          # Remove only trailing hyphens (keep leading dash from emoji)
             
             # Create TOC entry (no indentation for H2 only)
             $tocEntry = "- [$headingText](#$anchor)"


### PR DESCRIPTION
## 🐛 Bug Fix: TOC Anchor Links for Emoji Headings

### Problem
TOC anchor links were broken for all headings that start with emojis (e.g., 🎓 Core Concepts Overview). The script was removing leading dashes from anchors, but Jekyll generates anchors with leading dashes when headings start with emojis.

### Solution
Changed `Trim('-')` to `TrimEnd('-')` in the anchor generation logic to preserve leading dashes while still removing trailing ones.

**Example:**
- Heading: `## 🎓 Core Concepts Overview`
- Old anchor: `#core-concepts-overview` ❌ (broken)
- New anchor: `#-core-concepts-overview` ✅ (matches Jekyll)

### Changes
- Modified `scripts/Generate-Labs.ps1` anchor generation in `Generate-TOCFromHeadings` function
- Updated comment to clarify leading dash preservation
- Regenerated all 22 lab files with corrected TOC links

### Testing
- ✅ Regenerated all labs with corrected anchor format
- ✅ Regenerated all PDFs (21/22 successful, external lab expected to fail)
- ✅ Verified TOC links now include leading dash for emoji headings

### Impact
Fixes navigation for all labs with emoji-prefixed headings, improving user experience in both left navigation and in-page TOC links.
