### PR TITLE
feat: update Agent Build-A-Thon events to use Agent Builder in M365 lab

### DIFF
--- a/_data/lab-config.yml
+++ b/_data/lab-config.yml
@@ -196,10 +196,9 @@ legacy_lab_orders:
 
 lab_orders:
   event:
-    agent-buildathon-1day: [100, 120]
+    agent-buildathon-1day: [140, 120]
     agent-buildathon-1month:
-      - 100
-      - 210
+      - 140
       - 110
       - 120
       - 220
@@ -323,16 +322,16 @@ mcs_in_a_day_lab_orders:
   4: ask-me-anything-30-mins
   5: autonomous-support-agent
 
+agent_buildathon_1day_lab_orders:
+  1: agent-builder-m365
+  2: mbr-prep-sharepoint-agent
+
 azure_ai_workshop_lab_orders:
   1: dataverse-mcp-connector
   2: contract-alerts-azure-ai
   3: mcs-byom
   4: data-fabric-agent
   5: guildhall-custom-mcp
-
-agent_buildathon_1day_lab_orders:
-  1: agent-builder-web
-  2: mbr-prep-sharepoint-agent
 
 bootcamp_lab_orders:
   1: agent-builder-m365
@@ -345,12 +344,11 @@ bootcamp_lab_orders:
   8: data-fabric-agent
 
 agent_buildathon_1month_lab_orders:
-  1: agent-builder-web
-  2: agent-builder-sharepoint
-  3: public-website-agent
-  4: mbr-prep-sharepoint-agent
-  5: ask-me-anything
-  6: autonomous-support-agent
-  7: autonomous-account-news
-  8: autonomous-cua
+  1: agent-builder-m365
+  2: public-website-agent
+  3: mbr-prep-sharepoint-agent
+  4: ask-me-anything
+  5: autonomous-support-agent
+  6: autonomous-account-news
+  7: autonomous-cua
 

--- a/lab-config.yml
+++ b/lab-config.yml
@@ -381,15 +381,14 @@ events:
   agent-buildathon-1day:
     title: "🏗️ Agent Build-A-Thon (1 day)"
     description: "One-day intensive agent building workshop focused on creating web-based and SharePoint-integrated AI assistants."
-    lab_order: [agent-builder-web, mbr-prep-sharepoint-agent]
+    lab_order: [agent-builder-m365, mbr-prep-sharepoint-agent]
 
   agent-buildathon-1month:
     title: "🚀 Agent Build-A-Thon (1 month)"
     description: "Comprehensive month-long agent development program covering declarative agents, autonomous AI, and enterprise deployment patterns."
     lab_order:
       [
-        agent-builder-web,
-        agent-builder-sharepoint,
+        agent-builder-m365,
         public-website-agent,
         mbr-prep-sharepoint-agent,
         ask-me-anything,


### PR DESCRIPTION
## Summary

Updates Agent Build-A-Thon event configurations to use the Agent Builder in Microsoft 365 lab instead of the web-based agent builder lab.

## Changes

### Agent Build-A-Thon (1 day)
- **Lab 1**: Changed from `agent-builder-web` to `agent-builder-m365`

### Agent Build-A-Thon (1 month)
- **Lab 1**: Changed from `agent-builder-web` to `agent-builder-m365`
- **Lab 2**: Removed `agent-builder-sharepoint` from the sequence

## Rationale

The Agent Builder in Microsoft 365 lab (`agent-builder-m365`) provides a more comprehensive progressive learning experience compared to the basic web-based lab, making it a better starting point for both Build-A-Thon events.

## Testing

- ✅ Local Jekyll testing passed
- ✅ Event pages display correctly with updated labs
- ✅ Lab navigation works
- ✅ Configuration audit passes
