### PR TITLE
fix: Add concurrency control to GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -10,6 +10,18 @@
 name: 🚀 Build and Deploy Labs
 
 # =============================================================================
+# CONCURRENCY CONTROL
+# =============================================================================
+# Prevents multiple GitHub Pages deployments from running simultaneously
+# - Only one deployment per group runs at a time
+# - Newer deployments automatically cancel any in-progress older deployments
+# - Prevents race conditions and deployment conflicts
+# =============================================================================
+concurrency:
+  group: github-pages-deployment
+  cancel-in-progress: true
+
+# =============================================================================
 # WORKFLOW TRIGGERS
 # =============================================================================
 on:


### PR DESCRIPTION
## Summary

Adds concurrency control to the GitHub Pages deployment workflow to prevent race conditions and build failures caused by simultaneous deployments.

## Changes

- Added `concurrency` configuration with `github-pages-deployment` group
- Enabled `cancel-in-progress` to automatically cancel outdated deployment runs
- Added detailed comments explaining the concurrency control mechanism

## Problem Solved

Previously, when multiple commits were pushed in quick succession, concurrent GitHub Pages deployments could interfere with each other, causing build failures. This change ensures only one deployment runs at a time, with newer deployments automatically canceling older ones.

## Testing

- Workflow syntax validated
- Change follows GitHub Actions best practices for GitHub Pages deployments
- Ready for testing with next deployment trigger
