### PR TITLE
feat: Add setup-for-success lab as LAB 2 to Agent Build-A-Thon (1 month) event

### DIFF
--- a/_data/lab-config.yml
+++ b/_data/lab-config.yml
@@ -199,6 +199,7 @@ lab_orders:
     agent-buildathon-1day: [140, 120]
     agent-buildathon-1month:
       - 140
+      - 200
       - 110
       - 120
       - 220
@@ -315,24 +316,6 @@ event_configs:
     description: Fast-track full-day workshop introducing Microsoft Copilot Studio through hands-on labs covering declarative agents, custom agents, and autonomous AI.
     title: ⚡ MCS in a Day
 
-mcs_in_a_day_lab_orders:
-  1: agent-builder-m365
-  2: public-website-agent
-  3: mbr-prep-sharepoint-agent
-  4: ask-me-anything-30-mins
-  5: autonomous-support-agent
-
-agent_buildathon_1day_lab_orders:
-  1: agent-builder-m365
-  2: mbr-prep-sharepoint-agent
-
-azure_ai_workshop_lab_orders:
-  1: dataverse-mcp-connector
-  2: contract-alerts-azure-ai
-  3: mcs-byom
-  4: data-fabric-agent
-  5: guildhall-custom-mcp
-
 bootcamp_lab_orders:
   1: agent-builder-m365
   2: setup-for-success
@@ -343,12 +326,31 @@ bootcamp_lab_orders:
   7: autonomous-cua
   8: data-fabric-agent
 
+agent_buildathon_1day_lab_orders:
+  1: agent-builder-m365
+  2: mbr-prep-sharepoint-agent
+
 agent_buildathon_1month_lab_orders:
+  1: agent-builder-m365
+  2: setup-for-success
+  3: public-website-agent
+  4: mbr-prep-sharepoint-agent
+  5: ask-me-anything
+  6: autonomous-support-agent
+  7: autonomous-account-news
+  8: autonomous-cua
+
+mcs_in_a_day_lab_orders:
   1: agent-builder-m365
   2: public-website-agent
   3: mbr-prep-sharepoint-agent
-  4: ask-me-anything
+  4: ask-me-anything-30-mins
   5: autonomous-support-agent
-  6: autonomous-account-news
-  7: autonomous-cua
+
+azure_ai_workshop_lab_orders:
+  1: dataverse-mcp-connector
+  2: contract-alerts-azure-ai
+  3: mcs-byom
+  4: data-fabric-agent
+  5: guildhall-custom-mcp
 

--- a/lab-config.yml
+++ b/lab-config.yml
@@ -110,7 +110,7 @@ labs:
     section: intermediate
     order: 200
     journeys: [business-user, developer]
-    events: [bootcamp]
+    events: [bootcamp, agent-buildathon-1month]
 
   agent-builder-sharepoint:
     title: "Create your own SharePoint-based AI assistant with Agent Builder in Microsoft 365"
@@ -389,6 +389,7 @@ events:
     lab_order:
       [
         agent-builder-m365,
+        setup-for-success,
         public-website-agent,
         mbr-prep-sharepoint-agent,
         ask-me-anything,


### PR DESCRIPTION
## Summary

Adds the "Set yourself up for success & discover ALM best practices" lab as **LAB 2** to the Agent Build-A-Thon (1 month) event.

## Changes

- Added `agent-buildathon-1month` to the `events` list for the `setup-for-success` lab in `lab-config.yml`
- Updated `agent-buildathon-1month` event's `lab_order` to include `setup-for-success` as the second lab
- Auto-synced configuration to `_data/lab-config.yml`

## Lab Order (Agent Build-A-Thon 1 month)

1. Build Progressive AI Assistants with Agent Builder in Microsoft 365
2. **Set yourself up for success & discover ALM best practices** ✨ (newly added)
3. Give your public website chatbot a brain and make it an agent
4. Create a Monthly Business Review (MBR) Agent
5. Create an 'Ask me anything' agent for your employees
6. Create an autonomous support agent
7. Build an Autonomous Account News Assistant Agent
8. Build an autonomous agent that uses Computer Use

## Testing

- ✅ Local testing completed at http://localhost:4000/mcs-labs/labs/agent-buildathon-1month/
- ✅ Configuration audit passed
- ✅ Jekyll generation successful
- ✅ Lab appears correctly as LAB 2 in event page
