### PR TITLE
Update agent setup lab with licensing guide and file size correction

### DIFF
--- a/labs/copilot-studio-core-concepts-agent-setup/README.md
+++ b/labs/copilot-studio-core-concepts-agent-setup/README.md
@@ -78,7 +78,7 @@ This lab takes you through the foundational steps of agent creation - from initi
 ## ✅ Prerequisites
 
 * Access to Microsoft Copilot Studio (trial or licensed environment)
-* A document to upload as a knowledge source (PDF, Word, or text file) - or use the Copilot Studio Licensing Guide from Microsoft Learn
+* A document to upload as a knowledge source (PDF, Word, or text file) - or use the [Copilot Studio Licensing Guide (February 2026)](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/bade/documents/products-and-services/en-us/microsoft-365/1084694-Microsoft-Copilot-Studio-Licensing-Guide-February-2026-PUB.pdf)
 * Basic familiarity with web browsers and form filling
 
 ---
@@ -263,10 +263,10 @@ Add a document knowledge source to your agent and verify that it accurately answ
 
 3. Select **Upload files** from the knowledge source options.
 
-4. Upload the **Copilot Studio Licensing Guide** (if you have a copy) or any relevant PDF document about Copilot Studio or a topic of your choice.
+4. Download and upload the [**Copilot Studio Licensing Guide (February 2026)**](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/bade/documents/products-and-services/en-us/microsoft-365/1084694-Microsoft-Copilot-Studio-Licensing-Guide-February-2026-PUB.pdf) or any relevant PDF document about Copilot Studio or a topic of your choice.
 
 > [!TIP]
-> You can upload multiple file types including PDF, Word documents (.docx), PowerPoint (.pptx), and text files. Each file can be up to 50 MB.
+> You can upload multiple file types including PDF, Word documents (.docx), PowerPoint (.pptx), and text files. Each file can be up to 512 MB.
 
 5. Wait for the file to upload and process. You'll see a status indicator showing the indexing progress.
 


### PR DESCRIPTION
## Summary
- Added direct link to official Microsoft Copilot Studio Licensing Guide (February 2026 edition)
- Corrected maximum file upload size from 50 MB to 512 MB

## Changes
- Updated prerequisites section with clickable link to February 2026 licensing guide PDF
- Updated knowledge source upload instructions with direct download link
- Fixed file size limit in tip from incorrect 50 MB to correct 512 MB

## Files Modified
- `labs/copilot-studio-core-concepts-agent-setup/README.md`

## Test plan
- [ ] Verify licensing guide PDF link opens correctly
- [ ] Confirm file size update is accurate per Copilot Studio documentation
- [ ] Review instructions for clarity

🤖 Generated with [Claude Code](https://claude.com/claude-code)