### PR TITLE
fix: Update component collection name in Component Collections lab

### DIFF
--- a/labs/component-collections/README.md
+++ b/labs/component-collections/README.md
@@ -363,9 +363,9 @@ Manage component collection access, set a primary agent, and explore solution in
 
 1. In the left-hand navigation menu, click the **...** button and select **Component collections**.
 
-2. In the list, click on **Office Space Entities**.
+2. In the list, click on **Corporate Services**.
 
-3. Review the details about the Office Space Entities component collection, including what is included in it (2 different Entities).
+3. Review the details about the Corporate Services component collection, including what is included in it (Knowledge, 2 Entities, Topic, and Connector).
 
 #### Add an Agent to a Component Collection
 


### PR DESCRIPTION
## Summary

Fixes incorrect component collection name and description in the Component Collections lab to match the actual solution.

## Changes

- ✅ Changed component collection name from "Office Space Entities" to "Corporate Services"
- ✅ Updated component collection contents description to accurately reflect all included items:
  - Knowledge
  - 2 Entities
  - Topic
  - Connector

## Purpose

The lab instructions referenced "Office Space Entities" collection, but the actual solution uses "Corporate Services" collection. This fix ensures lab participants can follow the instructions successfully with the correct collection name and understand what components are included.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation correction
