### PR TITLE
fix: Update bug bash link to bootcamp event page

### DIFF
--- a/bug-bash.html
+++ b/bug-bash.html
@@ -15,7 +15,7 @@ description: How to report bugs during the MCS Labs Bug Bash event
 
     <div class="bug-bash-step">
       <h3>Step 1: Navigate to a Lab</h3>
-      <p>Open the <a href="{{ '/labs/' | relative_url }}" target="_blank">MCS Labs Portal</a> and navigate to the lab you are testing. Each lab page has a red <strong>Report Issue</strong> button in the top navigation bar.</p>
+      <p>Open the <a href="{{ '/labs/bootcamp/' | relative_url }}" target="_blank">MCS Labs Portal</a> and navigate to the lab you are testing. Each lab page has a red <strong>Report Issue</strong> button in the top navigation bar.</p>
       <div class="bug-bash-screenshot">
         <img src="{{ '/assets/images/bug-bash-lab-page-top.png' | relative_url }}" alt="Lab page showing the Report Issue button in the navigation bar" />
       </div>


### PR DESCRIPTION
## Description

Updates the Bug Bash guide link to point to the Bootcamp event page instead of the general labs index.

## Changes

- Updated bug bash guide "Step 1" link from `/labs/` to `/labs/bootcamp/`
- This directs users to the Bootcamp event page which is the primary event for bug bash testing

## Testing

- [ ] Local testing: Verify link points to http://localhost:4000/mcs-labs/labs/bootcamp/
- [ ] Verify bootcamp page loads correctly
- [ ] Verify "Report Issue" button appears on bootcamp labs

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
