### PR TITLE
fix: Update BUG-BASH.md portal link to bootcamp event page

### DIFF
--- a/BUG-BASH.md
+++ b/BUG-BASH.md
@@ -6,7 +6,7 @@ Welcome to the MCS Labs Bug Bash! Your goal is to work through the labs and repo
 
 ### Step 1: Navigate to a Lab
 
-Open the [MCS Labs Portal](https://microsoft.github.io/mcs-labs/) and navigate to the lab you are testing. Each lab page has a red **Report Issue** button in the top navigation bar.
+Open the [MCS Labs Portal](https://microsoft.github.io/mcs-labs/labs/bootcamp/) and navigate to the lab you are testing. Each lab page has a red **Report Issue** button in the top navigation bar.
 
 ![Lab page showing the Report Issue button in the navigation bar](assets/images/bug-bash-lab-page-top.png)
 


### PR DESCRIPTION
## Summary
- Updated the MCS Labs Portal link in `BUG-BASH.md` Step 1 to point to the Architecture Bootcamp event page (`/labs/bootcamp/`) instead of the root portal (`/`)
- This makes the markdown version consistent with `bug-bash.html`, which already used the correct bootcamp URL

## Test plan
- [ ] Verify the link in BUG-BASH.md navigates to https://microsoft.github.io/mcs-labs/labs/bootcamp/
- [ ] Confirm bug-bash.html still renders the correct bootcamp link

🤖 Generated with [Claude Code](https://claude.com/claude-code)