### PR TITLE
fix: Use README as source of truth for lab durations

### DIFF
--- a/lab-config.yml
+++ b/lab-config.yml
@@ -75,7 +75,7 @@ labs:
   agent-builder-m365:
     title: "Build Progressive AI Assistants with Agent Builder in Microsoft 365"
     difficulty: "Beginner to Intermediate"
-    duration: 40
+    duration: 30
     section: core
     order: 140
     journeys: [quick-start, business-user]
@@ -143,7 +143,7 @@ labs:
   setup-for-success:
     title: "Set yourself up for success & discover ALM best practices"
     difficulty: "Intermediate"
-    duration: 35
+    duration: 20
     section: intermediate
     order: 200
     journeys: [business-user, developer]

--- a/scripts/Generate-Labs.ps1
+++ b/scripts/Generate-Labs.ps1
@@ -1298,10 +1298,6 @@ function Get-AllLabsFromFolders {
                         if ($configLab.difficulty -match '(\d+)') {
                             $lab.difficulty = [int]$matches[1]
                         }
-                        # Use duration from config
-                        if ($configLab.duration) {
-                            $lab.duration = [int]$configLab.duration
-                        }
                         # Use section from config if specified
                         if ($configLab.section) {
                             $lab.section = $configLab.section


### PR DESCRIPTION
## Summary
- Removes the config duration override in `Generate-Labs.ps1` so lab durations are parsed from each lab's README Lab Details table
- Fixes two mismatched durations in `lab-config.yml` (`agent-builder-m365`: 40→30, `setup-for-success`: 35→20)

Closes #158

## Test plan
- [x] Ran `Generate-Labs.ps1 -SkipPDFs` — `agent-builder-m365` generates with `duration: 30`
- [x] Tested locally with Docker — site shows correct durations

🤖 Generated with [Claude Code](https://claude.com/claude-code)