### PR TITLE
Add optional Work tab experience steps to agent-builder-m365 lab

### DIFF
--- a/labs/agent-builder-m365/README.md
+++ b/labs/agent-builder-m365/README.md
@@ -196,7 +196,7 @@ Create, configure, and test a web-based Copilot agent that serves as a knowledge
 
    - 2a. Make sure you are on the **Work** tab.
 
-   - 2b. Type the following prompt and select send:
+   - 2b. Type the following prompt and select **Send**:
    
      ```text
      Tell me about labs that my organization has available to learn about Copilot Studio


### PR DESCRIPTION
## Summary
- Adds optional steps 2a-2c to Use Case 1 in the agent-builder-m365 lab so training participants can experience the **Work** tab's SharePoint-grounded behavior in Microsoft 365 Copilot
- Renames section headings to clearly distinguish "Test the Microsoft 365 Copilot experience" (Work tab) from "Test the Copilot Chat experience" (Web tab)
- Steps are gated behind an `[!IMPORTANT]` callout noting they require the CopilotStudioTraining tenant with an M365 Copilot license

## Test plan
- [x] Verify markdown renders correctly on GitHub (callout, sub-steps, code block)
- [x] Confirm step numbering flows logically: 1 → 2 → 2a/2b/2c → 3 → 4 → ...
- [x] Validate the prompt in step 2b returns SharePoint-grounded results on the CopilotStudioTraining tenant