### PR TITLE
Fix note callout formatting in governance lab

### DIFF
--- a/labs/mcs-governance/README.md
+++ b/labs/mcs-governance/README.md
@@ -257,8 +257,8 @@ Create a "Copilot Studio Advisor" agent in both the Green and Yellow zones, test
 
 #### Part 2: Yellow Zone (Microsoft Learn Allowed)
 
-    > [!NOTE]
-    > In a real organization, you would need to go through your company's approval process to get access to a Yellow zone environment. For this bootcamp we have pre-provisioned access.
+> [!NOTE]
+> In a real organization, you would need to go through your company's approval process to get access to a Yellow zone environment. For this bootcamp we have pre-provisioned access.
 
 1. Select the **Environment selector** in the top-right corner.
 
@@ -478,8 +478,8 @@ Create a "Copilot Studio Advisor" agent in the Red zone with full public website
 
 #### Bonus: Add and Explore the MCP Server
 
-    > [!NOTE]
-    > This section is for those who finish early. There are no detailed step-by-step instructions for this part, but here is what you need to know.
+> [!NOTE]
+> This section is for those who finish early. There are no detailed step-by-step instructions for this part, but here is what you need to know.
 
 1. Inside the Bootcamp Red environment, an MCP server has been pre-configured.
 


### PR DESCRIPTION
## Summary
- Fixed two `> [!NOTE]` callouts in the governance lab that were indented with 4 spaces, causing them to render as preformatted code blocks instead of styled notes
- **Yellow Zone section**: "In a real organization..." note
- **Bonus MCP Server section**: "This section is for those who finish early..." note

## Changes
| File | Change |
|------|--------|
| `labs/mcs-governance/README.md` | Removed 4-space indentation from two NOTE callouts |

## Test plan
- [x] Rebuilt Jekyll site locally and verified both notes render as blockquotes instead of code blocks
- [x] Confirmed no other content was affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)