### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,75 @@
+name: Bug Report
+description: Report a problem with a lab
+labels: ["type: bug"]
+body:
+  - type: dropdown
+    id: lab
+    attributes:
+      label: Which lab?
+      options:
+        - agent-buildathon-1day
+        - agent-buildathon-1month
+        - agent-builder-m365
+        - agent-builder-sharepoint
+        - agent-builder-web
+        - ask-me-anything
+        - ask-me-anything-30-mins
+        - autonomous-account-news
+        - autonomous-cua
+        - autonomous-support-agent
+        - azure-ai-workshop
+        - bootcamp
+        - component-collections
+        - contract-alerts-azure-ai
+        - copilot-studio-kit
+        - core-concepts-agent-knowledge-tools
+        - core-concepts-analytics-evaluations
+        - core-concepts-variables-agents-channels
+        - data-fabric-agent
+        - dataverse-mcp-connector
+        - guildhall-custom-mcp
+        - human-in-the-loop
+        - mbr-prep-sharepoint-agent
+        - mcp-qualify-lead
+        - mcs-alm
+        - mcs-byom
+        - mcs-governance
+        - mcs-in-a-day
+        - mcs-in-a-day-v2
+        - mcs-multi-agent
+        - mcs-tools
+        - measure-success
+        - pipelines-and-source-control
+        - public-website-agent
+        - setup-for-success
+        - standard-orchestrator
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened?
+      description: Describe the bug you encountered
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect?
+      description: What should have happened instead
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Which step in the lab were you on?
+      placeholder: |
+        1. Go to step X
+        2. Follow the instructions
+        3. See error...
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain the problem

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Copilot Studio Documentation
+    url: https://learn.microsoft.com/en-us/microsoft-copilot-studio/
+    about: Official Microsoft Copilot Studio documentation

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,53 @@
+name: Enhancement
+description: Suggest an improvement to an existing lab or to the site
+labels: ["type: lab-update"]
+body:
+  - type: dropdown
+    id: lab
+    attributes:
+      label: Which lab? (leave blank if site-wide)
+      options:
+        - (site-wide / not lab specific)
+        - agent-buildathon-1day
+        - agent-buildathon-1month
+        - agent-builder-m365
+        - agent-builder-sharepoint
+        - agent-builder-web
+        - ask-me-anything
+        - ask-me-anything-30-mins
+        - autonomous-account-news
+        - autonomous-cua
+        - autonomous-support-agent
+        - azure-ai-workshop
+        - bootcamp
+        - component-collections
+        - contract-alerts-azure-ai
+        - copilot-studio-kit
+        - core-concepts-agent-knowledge-tools
+        - core-concepts-analytics-evaluations
+        - core-concepts-variables-agents-channels
+        - data-fabric-agent
+        - dataverse-mcp-connector
+        - guildhall-custom-mcp
+        - human-in-the-loop
+        - mbr-prep-sharepoint-agent
+        - mcp-qualify-lead
+        - mcs-alm
+        - mcs-byom
+        - mcs-governance
+        - mcs-in-a-day
+        - mcs-in-a-day-v2
+        - mcs-multi-agent
+        - mcs-tools
+        - measure-success
+        - pipelines-and-source-control
+        - public-website-agent
+        - setup-for-success
+        - standard-orchestrator
+  - type: textarea
+    id: proposal
+    attributes:
+      label: What should change and why?
+      description: Describe the improvement you'd like to see
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/new_lab.yml
+++ b/.github/ISSUE_TEMPLATE/new_lab.yml
@@ -1,0 +1,44 @@
+name: New Lab Proposal
+description: Propose a new lab for the collection
+labels: ["type: new-lab"]
+body:
+  - type: input
+    id: title
+    attributes:
+      label: Lab title
+      description: A short, descriptive title for the lab
+      placeholder: "e.g., Build a Dataverse MCP Connector"
+    validations:
+      required: true
+  - type: textarea
+    id: scenario
+    attributes:
+      label: What will the learner build?
+      description: Describe the end-to-end scenario and what the learner will have built by the end
+    validations:
+      required: true
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Difficulty
+      options:
+        - Beginner
+        - Intermediate
+        - Advanced
+    validations:
+      required: true
+  - type: textarea
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      description: What does the learner need before starting?
+      placeholder: |
+        - Copilot Studio environment
+        - Azure subscription
+        - ...
+  - type: textarea
+    id: duration
+    attributes:
+      label: Estimated duration
+      description: How long should this lab take?
+      placeholder: "e.g., 30 minutes, 1 hour"


### PR DESCRIPTION
## Summary
- Adds structured YAML issue form templates: bug report, new lab proposal, enhancement request
- Each template auto-labels and includes a lab dropdown for easy categorization
- Adds `config.yml` to enable blank issues and link to Copilot Studio docs

Part of project board setup: https://github.com/orgs/microsoft/projects/2214

## Files
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/new_lab.yml`
- `.github/ISSUE_TEMPLATE/enhancement.yml`
- `.github/ISSUE_TEMPLATE/config.yml`

## Test plan
- [ ] Verify templates appear at https://github.com/microsoft/mcs-labs/issues/new/choose after merge
- [ ] Test each form renders correctly with dropdowns

🤖 Generated with [Claude Code](https://claude.com/claude-code)