### PR TITLE
Dewain: Update homepage hero, section order, and chat flyout label

### DIFF
--- a/_includes/webchat/panel.html
+++ b/_includes/webchat/panel.html
@@ -3,7 +3,7 @@
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
   </svg>
-  <span class="wc-tag-label">Ask</span>
+  <span class="wc-tag-label">Lab Assistant</span>
 </div>
 
 <!-- Overlay -->

--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -67,7 +67,6 @@
   function open() {
     isOpen = true;
     panel.classList.add('wc-panel--open');
-    overlay.classList.add('wc-overlay--visible');
     tag.classList.add('wc-tag--hidden');
     panel.addEventListener('keydown', handleFocusTrap);
     if (!chatInitializing && !chatReady) initChat();
@@ -77,7 +76,6 @@
   function close() {
     isOpen = false;
     panel.classList.remove('wc-panel--open');
-    overlay.classList.remove('wc-overlay--visible');
     tag.classList.remove('wc-tag--hidden');
     panel.removeEventListener('keydown', handleFocusTrap);
     tag.focus();
@@ -88,7 +86,6 @@
     if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
   });
   closeBtn.addEventListener('click', close);
-  overlay.addEventListener('click', close);
 
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape' && isOpen) close();

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -46,22 +46,9 @@
   opacity: 0;
 }
 
-/* --- Overlay --- */
+/* --- Overlay (removed — panel flies out without blocking page) --- */
 .wc-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(15, 27, 45, 0.06);
-  z-index: 99991;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.3s ease;
-  backdrop-filter: blur(1px);
-  -webkit-backdrop-filter: blur(1px);
-}
-
-.wc-overlay.wc-overlay--visible {
-  opacity: 1;
-  pointer-events: auto;
+  display: none;
 }
 
 /* --- Panel --- */

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -43,7 +43,13 @@ $monospace: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace !default;
   .page__content:has(> .sidebar__right) > *:not(.sidebar__right) {
     grid-column: 1;
     min-width: 0;     // prevent grid blowout from wide tables/code
-    overflow-x: auto; // scroll wide tables within column
+  }
+
+  // Only scroll wide tables and code blocks, not all children
+  .page__content table,
+  .page__content div.highlighter-rouge,
+  .page__content figure.highlight {
+    overflow-x: auto;
   }
 
   // TOC sidebar spans full height, sticks on scroll
@@ -84,8 +90,9 @@ aside.sidebar__right {
   .toc__menu {
     padding: 0;
 
-    // Only show top-level (h2) items
-    ul { display: none; }
+    // Show h2 items and their h3 children, hide deeper nesting
+    > li > ul { display: block; }
+    ul ul { display: none; }
 
     a {
       font-size: 0.78em;
@@ -246,26 +253,53 @@ p > code, li > code, td > code {
 // Lab header (rendered by _layouts/lab.html)
 // ---------------------------------------------------------------------------
 .lab-header {
-  margin: -0.5em 0 1em;
-  padding-bottom: 0.8em;
-  border-bottom: 1px solid #e8e6e4;
+  background: linear-gradient(135deg, #0f1b2d 0%, #1a3a5c 50%, #0f2440 100%);
+  color: #fff;
+  padding: 2em 2em 1.5em;
+  border-radius: 10px;
+  margin: -0.5em 0 1.5em;
+  position: relative;
+  overflow: hidden;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: -40%;
+    right: -15%;
+    width: 350px;
+    height: 350px;
+    background: radial-gradient(circle, rgba(0,120,212,0.12) 0%, transparent 70%);
+    pointer-events: none;
+  }
 
   h1 {
     font-size: 1.4em;
     font-weight: 700;
     letter-spacing: -0.01em;
-    color: #323130;
+    color: #fff;
     margin: 0 0 0.3em;
     line-height: 1.3;
+    border: none;
+    padding: 0;
   }
 }
 
 .lab-header-desc {
   font-size: 0.9em;
-  color: #605e5c;
+  color: rgba(255, 255, 255, 0.8);
   line-height: 1.5;
-  margin: 0 0 0.6em;
+  margin: 0 0 0.8em;
 }
+
+// Hide duplicate H1 title, description, and surrounding hrs from markdown content
+.lab-header + hr { display: none; }
+.lab-header + hr + h1 { display: none; }
+.lab-header + hr + h1 + p { display: none; }
+.lab-header + hr + h1 + p + hr { display: none; }
+// Also handle case without leading hr
+.lab-header + h1 { display: none; }
+.lab-header + h1 + p { display: none; }
+.lab-header + h1 + p + hr { display: none; }
 
 .lab-header-meta {
   display: flex;
@@ -281,13 +315,13 @@ p > code, li > code, td > code {
   border-radius: 100px;
   white-space: nowrap;
 }
-.lab-meta-pill-duration { background: #f3f2f1; color: #605e5c; }
-.lab-meta-pill-level-100 { background: #e6f2e6; color: #0e700e; }
-.lab-meta-pill-level-200 { background: #deecf9; color: #004578; }
-.lab-meta-pill-level-300 { background: #f0e6fc; color: #5b2d8e; }
-.lab-meta-pill-section { background: #fff; color: #605e5c; border: 1px solid #e1dfdd; }
-.lab-meta-pill-feedback { background: #fff; color: #0078d4; border: 1px solid #0078d4; text-decoration: none; cursor: pointer; }
-.lab-meta-pill-feedback:hover { background: #0078d4; color: #fff; }
+.lab-meta-pill-duration { background: rgba(255,255,255,0.15); color: rgba(255,255,255,0.9); }
+.lab-meta-pill-level-100 { background: rgba(16,124,16,0.25); color: #a3e4a3; }
+.lab-meta-pill-level-200 { background: rgba(0,120,212,0.25); color: #9ecbf6; }
+.lab-meta-pill-level-300 { background: rgba(127,57,251,0.25); color: #c9a8fc; }
+.lab-meta-pill-section { background: rgba(255,255,255,0.1); color: rgba(255,255,255,0.8); border: 1px solid rgba(255,255,255,0.2); }
+.lab-meta-pill-feedback { background: rgba(255,255,255,0.1); color: rgba(255,255,255,0.8); border: 1px solid rgba(255,255,255,0.25); text-decoration: none; cursor: pointer; }
+.lab-meta-pill-feedback:hover { background: rgba(255,255,255,0.2); color: #fff; }
 
 // ---------------------------------------------------------------------------
 // Misc

--- a/index.md
+++ b/index.md
@@ -193,10 +193,10 @@ header:
 
 <div class="home-hero">
   <h2>Hands-on labs for building AI agents</h2>
-  <p>Learn Microsoft Copilot Studio through guided, practical labs. From your first agent to autonomous AI — choose a path that matches your skill level.</p>
+  <p>Learn Microsoft Copilot agents through guided, practical labs. From your first agent to autonomous AI — choose a path that matches your skill level.</p>
   <div class="home-hero-actions">
-    <a href="{{ '/labs/' | relative_url }}" class="btn-primary">Browse all labs</a>
-    <a href="{{ '/workshops/bootcamp/' | relative_url }}" class="btn-outline">Start bootcamp</a>
+    <a href="{{ '/workshops/' | relative_url }}" class="btn-primary">Browse all workshops</a>
+    <a href="{{ '/labs/' | relative_url }}" class="btn-outline">Browse all labs</a>
   </div>
   <ul class="home-stats">
     <li><strong>{{ all_labs.size }}</strong><span>Labs</span></li>
@@ -205,6 +205,24 @@ header:
     <li><strong>{{ all_workshops.size }}</strong><span>Workshops</span></li>
   </ul>
 </div>
+
+{% assign accent_colors = "accent-blue,accent-green,accent-purple,accent-orange" | split: "," %}
+
+<h2 class="home-section-title">Workshops &amp; events</h2>
+<ul class="journey-grid">
+  {% for workshop in all_workshops %}
+  {% assign color_idx = forloop.index0 | modulo: 4 %}
+  <li class="journey-card">
+    <div class="journey-card-accent {{ accent_colors[color_idx] }}"></div>
+    <h3><a href="{{ workshop.url | relative_url }}">{{ workshop.title }}</a></h3>
+    <div class="journey-card-desc">{{ workshop.description | truncate: 120 }}</div>
+    <div class="journey-card-meta">
+      <span class="journey-pill">Full day</span>
+      <span class="journey-pill">{{ workshop.labs.size }} labs</span>
+    </div>
+  </li>
+  {% endfor %}
+</ul>
 
 <h2 class="home-section-title">Learning paths</h2>
 <ul class="journey-grid">
@@ -248,22 +266,4 @@ header:
       <span class="journey-pill">3 labs</span>
     </div>
   </li>
-</ul>
-
-{% assign accent_colors = "accent-blue,accent-green,accent-purple,accent-orange" | split: "," %}
-
-<h2 class="home-section-title">Workshops &amp; events</h2>
-<ul class="journey-grid">
-  {% for workshop in all_workshops %}
-  {% assign color_idx = forloop.index0 | modulo: 4 %}
-  <li class="journey-card">
-    <div class="journey-card-accent {{ accent_colors[color_idx] }}"></div>
-    <h3><a href="{{ workshop.url | relative_url }}">{{ workshop.title }}</a></h3>
-    <div class="journey-card-desc">{{ workshop.description | truncate: 120 }}</div>
-    <div class="journey-card-meta">
-      <span class="journey-pill">Full day</span>
-      <span class="journey-pill">{{ workshop.labs.size }} labs</span>
-    </div>
-  </li>
-  {% endfor %}
 </ul>


### PR DESCRIPTION
## Summary

- **Hero buttons**: Replaced "Browse all labs" (primary) + "Start bootcamp" (outline) with "Browse all workshops" + "Browse all labs" — we haven't determined which bootcamp or workshop to feature on the landing page yet
- **Hero text**: Changed "Copilot Studio" to "Copilot agents" to reflect the broader scope of labs and workshops beyond just Copilot Studio
- **Section order**: Moved "Workshops & Events" above "Learning Paths" for better visibility
- **Chat flyout label**: Renamed the side-panel toggle from "Ask" to "Lab Assistant" for clarity
- **Chat flyout overlay removed**: The page overlay/gradient is no longer shown when the Lab Assistant panel is expanded — users can still interact with the main page behind the chat panel
- **Lab header redesign**: Styled lab header with a dark gradient hero (matching the site's homepage/event hero style) so it is clearly distinguishable as the page header
- **Duplicate title removed**: Hidden the duplicate H1 title and description that appeared from the markdown content below the styled header
- **Scrollbar fix**: Fixed unwanted scrollbar on lab pages by scoping `overflow-x: auto` to only tables and code blocks instead of all grid children
- **Pill colors updated**: Lab metadata pills (level, duration, section, feedback) updated for contrast on the dark hero background
- **TOC sub-items**: Enabled h3 sub-items in the "On this page" sidebar so use case sections are visible

## Test plan

- [ ] Verify homepage hero shows "Browse all workshops" and "Browse all labs" buttons
- [ ] Confirm "Browse all workshops" links to `/workshops/` and "Browse all labs" links to `/labs/`
- [ ] Verify "Workshops & Events" section appears before "Learning Paths"
- [ ] Verify chat flyout tab reads "Lab Assistant" instead of "Ask"
- [ ] Open the Lab Assistant chat panel and verify the page behind it is still scrollable and interactive (no overlay/gradient)
- [ ] Verify lab pages show a dark gradient header with title, description, and colored pills
- [ ] Confirm no duplicate title or scrollbar appears below the lab header
- [ ] Verify "On this page" TOC shows h2 sections and h3 sub-items (e.g., Use Case #1, #2)