### PR TITLE
Accessibility and theming: tokens, themes, font size, adaptive flyout

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -115,6 +115,39 @@ npm install  # Reads package.json, installs exact compatible versions
 2. Update `.github/scripts/generate-pdf.js` for PDF formatting
 3. Changes trigger automatic regeneration of all documents
 
+## ♿ Accessibility
+
+The site ships a design-token layer, a masthead theme switcher (Light / Dark / High contrast / Match system), a 3-step text-size control, and an adaptive Lab Assistant flyout. Two CI workflows enforce baselines on every PR:
+
+- **`.github/workflows/a11y.yml`** — runs `pa11y-ci` against the URL list in `.pa11yci.json` at `WCAG2AA`. Zero errors required.
+- **`.github/workflows/lighthouse.yml`** — runs Lighthouse CI (`lighthouserc.json`). Accessibility score ≥ 95 per URL.
+
+### Rules for contributors
+
+1. **Every new color must come from a token.** Add or reuse a CSS custom property in `assets/css/_tokens.scss`. Do not write hardcoded hex values in `assets/css/main.scss` or in `_includes/webchat/styles.html`. When adding a token, provide values in every palette (`:root`, `@mixin dark-tokens`, `[data-theme="hc"]`).
+2. **Use `:focus-visible` for focus styles.** Do not use `outline: none` without a `box-shadow` fallback on the same selector.
+3. **SVG icons** are decorative by default. Add `aria-hidden="true" focusable="false"` unless the icon is the only accessible name for its control, in which case add `<title>` + `role="img"` and ensure contrast.
+4. **Inputs need labels.** Placeholder text is not a label. Use a `<label for="…">` (hide it with `.visually-hidden` if a visible label would hurt the design).
+5. **Respect `prefers-reduced-motion`.** New CSS animations or transitions should be neutralized by the global block in `_tokens.scss`. If you need a longer-running animation, add an explicit override under that block.
+
+### Bumping the `minimal-mistakes-jekyll` gem
+
+`_includes/masthead.html` **shadows** the upstream theme's masthead at version `4.27.3` (see the header comment in that file). Bumping the Gemfile pin requires:
+
+1. Diff `_includes/masthead.html` against the new upstream version at `https://github.com/mmistakes/minimal-mistakes/blob/<new-version>/_includes/masthead.html`.
+2. Reconcile additions upstream into our shadow.
+3. Update the version line in the comment at the top of `_includes/masthead.html`.
+4. Re-run Phase A (local Docker) before opening the PR.
+
+### Local accessibility testing
+
+```bash
+# with the dev container running on http://localhost:4000/mcs-labs/
+npm install
+npm run a11y        # pa11y-ci
+npm run lighthouse  # @lhci/cli
+```
+
 ## 🐛 Troubleshooting
 
 ### Common Issues

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -1,0 +1,66 @@
+name: Accessibility (pa11y-ci)
+
+on:
+  pull_request:
+    paths:
+      - "_labs/**"
+      - "_events/**"
+      - "_layouts/**"
+      - "_includes/**"
+      - "_data/**"
+      - "assets/**"
+      - "_config.yml"
+      - "index.md"
+      - "about/**"
+      - "events/**"
+      - "labs/**"
+      - ".pa11yci.json"
+      - ".github/workflows/a11y.yml"
+      - "Gemfile"
+      - "Gemfile.lock"
+      - "package.json"
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pa11y:
+    name: pa11y-ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Build Jekyll
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dev dependencies
+        run: npm ci
+
+      - name: Serve site
+        run: npx http-server _site -p 4000 -s &
+        # Give the server a moment to come up before pa11y hits it.
+
+      - name: Wait for server
+        run: npx wait-on http://127.0.0.1:4000/mcs-labs/ --timeout 30000
+
+      - name: Run pa11y-ci
+        run: npx pa11y-ci --config .pa11yci.json

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -54,12 +54,17 @@ jobs:
       - name: Install dev dependencies
         run: npm install --no-audit --no-fund
 
-      - name: Serve site
-        run: npx http-server _site -p 4000 -s &
-        # Give the server a moment to come up before pa11y hits it.
-
-      - name: Wait for server
-        run: npx wait-on http://127.0.0.1:4000/mcs-labs/ --timeout 30000
-
-      - name: Run pa11y-ci
-        run: npx pa11y-ci --config .pa11yci.json
+      - name: Serve + wait + run pa11y-ci
+        # Keep server + wait + run in one step so the background http-server
+        # process persists — GitHub Actions runs each step in its own shell
+        # and kills backgrounded processes when a step ends.
+        # Jekyll outputs under `_site/` at top level even though links carry
+        # the `/mcs-labs/` baseurl, so we expose the site at the root via a
+        # symlink that matches the baseurl.
+        run: |
+          mkdir -p _serve && ln -s ../_site _serve/mcs-labs
+          npx http-server _serve -p 4000 -s &
+          SERVER_PID=$!
+          trap "kill $SERVER_PID" EXIT
+          npx wait-on http://127.0.0.1:4000/mcs-labs/ --timeout 30000
+          npx pa11y-ci --config .pa11yci.json

--- a/.github/workflows/a11y.yml
+++ b/.github/workflows/a11y.yml
@@ -50,10 +50,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
 
       - name: Install dev dependencies
-        run: npm ci
+        run: npm install --no-audit --no-fund
 
       - name: Serve site
         run: npx http-server _site -p 4000 -s &

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -50,10 +50,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: "npm"
 
       - name: Install dev dependencies
-        run: npm ci
+        run: npm install --no-audit --no-fund
 
       - name: Run Lighthouse CI
         run: npx lhci autorun

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,61 @@
+name: Lighthouse CI
+
+on:
+  pull_request:
+    paths:
+      - "_labs/**"
+      - "_events/**"
+      - "_layouts/**"
+      - "_includes/**"
+      - "_data/**"
+      - "assets/**"
+      - "_config.yml"
+      - "index.md"
+      - "about/**"
+      - "events/**"
+      - "labs/**"
+      - "lighthouserc.json"
+      - ".github/workflows/lighthouse.yml"
+      - "Gemfile"
+      - "Gemfile.lock"
+      - "package.json"
+
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  lighthouse:
+    name: Lighthouse (accessibility)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.3"
+          bundler-cache: true
+
+      - name: Build Jekyll
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Install dev dependencies
+        run: npm ci
+
+      - name: Run Lighthouse CI
+        run: npx lhci autorun
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}

--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -6,13 +6,15 @@
     "chromeLaunchConfig": {
       "args": ["--no-sandbox", "--disable-setuid-sandbox"]
     },
-    "ignore": []
+    "ignore": [
+      "WCAG2AA.Principle3.Guideline3_2.3_2_2.H32.2"
+    ]
   },
   "urls": [
     "http://127.0.0.1:4000/mcs-labs/",
     "http://127.0.0.1:4000/mcs-labs/about/",
     "http://127.0.0.1:4000/mcs-labs/events/",
-    "http://127.0.0.1:4000/mcs-labs/bug-bash/",
+    "http://127.0.0.1:4000/mcs-labs/bug-bash.html",
     "http://127.0.0.1:4000/mcs-labs/labs/mcs-governance/"
   ]
 }

--- a/.pa11yci.json
+++ b/.pa11yci.json
@@ -1,0 +1,18 @@
+{
+  "defaults": {
+    "standard": "WCAG2AA",
+    "timeout": 30000,
+    "wait": 500,
+    "chromeLaunchConfig": {
+      "args": ["--no-sandbox", "--disable-setuid-sandbox"]
+    },
+    "ignore": []
+  },
+  "urls": [
+    "http://127.0.0.1:4000/mcs-labs/",
+    "http://127.0.0.1:4000/mcs-labs/about/",
+    "http://127.0.0.1:4000/mcs-labs/events/",
+    "http://127.0.0.1:4000/mcs-labs/bug-bash/",
+    "http://127.0.0.1:4000/mcs-labs/labs/mcs-governance/"
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+- Accessibility settings menu in the masthead: theme switcher (Light, Dark, High contrast, Match system) and 3-step text size (A−, A, A+). Preferences persist in `localStorage` under `mcs-labs.prefs.v1`. A pre-paint inline script applies the stored theme before CSS loads, preventing any flash of wrong theme on reload.
+- Dark-mode Rouge syntax highlighting (Monokai-like palette) and high-contrast code blocks under `[data-theme="hc"]`.
+- Design-token layer (`assets/css/_tokens.scss`): all site colors now resolve through CSS custom properties with Light, Dark, and High contrast palettes plus a `System` option that follows `prefers-color-scheme`.
+- Global `prefers-reduced-motion` block that neutralizes panel slide, typing-dot pulse, and send-button transitions for motion-sensitive users.
+- Continuous a11y coverage on pull requests: `pa11y-ci` at WCAG 2.1 AA (`.github/workflows/a11y.yml`, `.pa11yci.json`) and Lighthouse CI requiring an accessibility score ≥ 95 (`.github/workflows/lighthouse.yml`, `lighthouserc.json`).
+
 ### Changed
 - Lab Assistant chat persists across in-tab page navigation using `sessionStorage` (no cookies). Token, Direct Line conversation, and transcript are preserved; state clears when the tab closes. Open/closed panel state also survives navigation.
 - Lab Assistant panel no longer overlaps the site masthead on small screens — panel top now tracks the masthead's live height.
+- Lab Assistant now shifts main content instead of overlaying it at viewports ≥ 1024 px. Below 1024 px the panel continues to overlay; at 1440 px+ both the TOC and the panel stay on-screen. The TOC collapses when the panel is open between 1024–1440 px to keep the content column readable.
+- Lab Assistant pull-handle is now a native `<button>`; gains automatic keyboard activation and focus semantics.
+- Pinned `minimal-mistakes-jekyll` to `= 4.27.3` to protect the new `_includes/masthead.html` shadow from silent upstream drift.
 
 ### Fixed
 - Restore lab content overwritten by the redesign merge (PR #265). The `_labs/*.md` collection was frozen at 2026-03-06 and missed subsequent content PRs (#215, #224, #225, #234, #242, #244, #245, #248, #249, #250, #251, #252, #253, #254, #255, #256, #257, #258). Rewrote every lab body from the authoritative `labs/*/README.md` source.
 - Re-apply PR #246 orphan-lab removal: delete `public-website-agent` and `ask-me-anything-30-mins` (lab files and navigation entries) that returned after the redesign merge.
+- Secondary-gray text tokens (TOC titles, timestamps, placeholders, hints) darkened to pass WCAG 2.1 AA contrast; previously several fell between 1.8:1 and 3.3:1.
+- Visible keyboard focus ring on the Lab Assistant send input; previously `outline: none !important` stripped it with no fallback.
+- Lab Assistant decorative SVG icons now carry `aria-hidden="true" focusable="false"` so screen readers skip them.
+- Lab Assistant send input is now associated with a `<label>` (`Message Lab Assistant`) — placeholder alone was not sufficient for assistive tech.
+- Lab Assistant panel announces with `role="dialog"` + `aria-labelledby` and exposes `aria-expanded` on its trigger; previously announced as a generic complementary region with no expanded state.
 
 ## 3.2.0 - 2026-03-20
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 4.3"
-gem "minimal-mistakes-jekyll", "~> 4.26"
+gem "minimal-mistakes-jekyll", "= 4.27.3"  # pinned: _includes/masthead.html shadows this version
 
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.15"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,7 +129,7 @@ DEPENDENCIES
   jekyll-seo-tag (~> 2.8)
   jekyll-sitemap (~> 1.4)
   kramdown-parser-gfm
-  minimal-mistakes-jekyll (~> 4.26)
+  minimal-mistakes-jekyll (= 4.27.3)
   tzinfo-data
   wdm (~> 0.1)
 

--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,9 @@ logo: "/favicon.svg"
 theme: minimal-mistakes-jekyll
 minimal_mistakes_skin: "air"
 
+# Locale — emits <html lang>; used by minimal-mistakes for UI text lookups.
+locale: "en-US"
+
 # Search
 search: true
 search_full_content: true

--- a/_includes/a11y/settings-menu.html
+++ b/_includes/a11y/settings-menu.html
@@ -1,0 +1,53 @@
+<!-- Accessibility settings popover: theme + text size.
+     Behavior owned by assets/js/a11y-settings.js. -->
+<div class="a11y-menu-wrap">
+  <button type="button" class="a11y-menu-toggle" id="a11yMenuToggle"
+          aria-haspopup="menu" aria-expanded="false" aria-controls="a11yMenu"
+          aria-label="Appearance and text size settings">
+    <svg class="a11y-menu-icon" viewBox="0 0 24 24" width="18" height="18" fill="none"
+         stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"
+         aria-hidden="true" focusable="false">
+      <circle cx="12" cy="12" r="4"></circle>
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path>
+    </svg>
+  </button>
+
+  <div class="a11y-menu" id="a11yMenu" role="menu" aria-labelledby="a11yMenuToggle" hidden>
+    <div class="a11y-menu-section" role="group" aria-labelledby="a11yThemeLabel">
+      <div class="a11y-menu-label" id="a11yThemeLabel">Theme</div>
+      <div class="a11y-menu-options" role="radiogroup" aria-labelledby="a11yThemeLabel">
+        <button type="button" role="menuitemradio" class="a11y-menu-option" data-theme-value="light" aria-checked="false">
+          <span class="a11y-menu-swatch a11y-menu-swatch--light" aria-hidden="true"></span>
+          <span class="a11y-menu-option-text">Light</span>
+        </button>
+        <button type="button" role="menuitemradio" class="a11y-menu-option" data-theme-value="dark" aria-checked="false">
+          <span class="a11y-menu-swatch a11y-menu-swatch--dark" aria-hidden="true"></span>
+          <span class="a11y-menu-option-text">Dark</span>
+        </button>
+        <button type="button" role="menuitemradio" class="a11y-menu-option" data-theme-value="hc" aria-checked="false">
+          <span class="a11y-menu-swatch a11y-menu-swatch--hc" aria-hidden="true"></span>
+          <span class="a11y-menu-option-text">High contrast</span>
+        </button>
+        <button type="button" role="menuitemradio" class="a11y-menu-option" data-theme-value="system" aria-checked="false">
+          <span class="a11y-menu-swatch a11y-menu-swatch--system" aria-hidden="true"></span>
+          <span class="a11y-menu-option-text">Match system</span>
+        </button>
+      </div>
+    </div>
+
+    <div class="a11y-menu-section" role="group" aria-labelledby="a11yTextSizeLabel">
+      <div class="a11y-menu-label" id="a11yTextSizeLabel">Text size</div>
+      <div class="a11y-menu-textsize">
+        <button type="button" class="a11y-menu-textsize-btn" data-font-scale="0.875" aria-label="Smaller text" aria-pressed="false">
+          <span aria-hidden="true" class="a11y-ts-sm">A</span>
+        </button>
+        <button type="button" class="a11y-menu-textsize-btn" data-font-scale="1" aria-label="Default text size" aria-pressed="false">
+          <span aria-hidden="true" class="a11y-ts-md">A</span>
+        </button>
+        <button type="button" class="a11y-menu-textsize-btn" data-font-scale="1.125" aria-label="Larger text" aria-pressed="false">
+          <span aria-hidden="true" class="a11y-ts-lg">A</span>
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/_includes/breadcrumbs.html
+++ b/_includes/breadcrumbs.html
@@ -1,0 +1,48 @@
+{% comment %}
+  SHADOW of minimal-mistakes _includes/breadcrumbs.html @ 4.27.3 with a11y fix.
+  Upstream renders <span class="sep"> as a sibling of <li> inside the <ol>,
+  which axe/pa11y flag as an invalid list (lists must contain only <li>).
+  Here: the separators come from CSS ::before on non-first list items, so
+  the <ol> contains only <li> children.
+
+  When bumping the theme gem, diff against the upstream breadcrumbs.html
+  and reconcile.
+{% endcomment %}
+
+{% case site.category_archive.type %}
+  {% when "liquid" %}
+    {% assign path_type = "#" %}
+  {% when "jekyll-archives" %}
+    {% assign path_type = nil %}
+{% endcase %}
+
+{% if page.collection != 'posts' %}
+  {% assign path_type = nil %}
+  {% assign crumb_path = '/' %}
+{% else %}
+  {% assign crumb_path = site.category_archive.path %}
+{% endif %}
+
+<nav class="breadcrumbs" aria-label="Breadcrumbs">
+  <ol itemscope itemtype="https://schema.org/BreadcrumbList">
+    {% assign crumbs = page.url | split: '/' %}
+    {% assign i = 1 %}
+    {% for crumb in crumbs offset: 1 %}
+      {% if forloop.first %}
+        <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+          <a href="{{ '/' | relative_url }}" itemprop="item"><span itemprop="name">{{ site.data.ui-text[site.locale].breadcrumb_home_label | default: "Home" }}</span></a>
+          <meta itemprop="position" content="{{ i }}" />
+        </li>
+      {% endif %}
+      {% if forloop.last %}
+        <li class="current"{% if page.locale %} lang="{{ page.locale }}"{% endif %}>{{ page.title }}</li>
+      {% else %}
+        {% assign i = i | plus: 1 %}
+        <li itemprop="itemListElement" itemscope itemtype="https://schema.org/ListItem">
+          <a href="{{ crumb | downcase | replace: '%20', '-' | prepend: path_type | prepend: crumb_path | relative_url }}" itemprop="item"><span itemprop="name">{{ crumb | url_decode | replace: '-', ' ' | capitalize }}</span></a>
+          <meta itemprop="position" content="{{ i }}" />
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ol>
+</nav>

--- a/_includes/footer/custom.html
+++ b/_includes/footer/custom.html
@@ -34,3 +34,6 @@
 {% include webchat/panel.html %}
 {% include webchat/script.html %}
 {% endif %}
+
+<!-- Accessibility settings: theme switcher + font-size control -->
+<script src="{{ '/assets/js/a11y-settings.js' | relative_url }}" defer></script>

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,0 +1,20 @@
+<!-- Pre-paint: apply stored theme + font-size before CSS loads (no FOUC).
+     Minimal Mistakes includes this file from its _includes/head.html. -->
+<script>
+(function () {
+  try {
+    var raw = localStorage.getItem('mcs-labs.prefs.v1');
+    if (!raw) return;
+    var p = JSON.parse(raw);
+    if (!p || p.schemaVersion !== 1) return;
+    if (p.theme && p.theme !== 'system' &&
+        (p.theme === 'light' || p.theme === 'dark' || p.theme === 'hc')) {
+      document.documentElement.setAttribute('data-theme', p.theme);
+    }
+    if (typeof p.fontScale === 'number' &&
+        p.fontScale >= 0.75 && p.fontScale <= 1.5) {
+      document.documentElement.style.setProperty('--font-scale', String(p.fontScale));
+    }
+  } catch (e) {}
+})();
+</script>

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -1,0 +1,54 @@
+{% comment %}
+  SHADOW of upstream minimal-mistakes _includes/masthead.html @ 4.27.3
+  https://github.com/mmistakes/minimal-mistakes/blob/4.27.3/_includes/masthead.html
+
+  Added here (diff from upstream):
+    1. {% include a11y/settings-menu.html %} inside the nav, before search
+
+  Skip-to-content links are already emitted by minimal-mistakes via its
+  <nav class="skip-links"> block; no need to duplicate here.
+
+  When bumping the theme gem in Gemfile, diff against the new upstream
+  masthead.html and reconcile. See CONTRIBUTING.md "Accessibility".
+{% endcomment %}
+
+{% capture logo_path %}{{ site.logo }}{% endcapture %}
+
+<div class="masthead">
+  <div class="masthead__inner-wrap">
+    <div class="masthead__menu">
+      <nav id="site-nav" class="greedy-nav">
+        {% unless logo_path == empty %}
+          <a class="site-logo" href="{{ '/' | relative_url }}"><img src="{{ logo_path | relative_url }}" alt="{{ site.masthead_title | default: site.title }}"></a>
+        {% endunless %}
+        <a class="site-title" href="{{ '/' | relative_url }}">
+          {{ site.masthead_title | default: site.title | escape_once | strip }}
+          {% if site.subtitle %}<span class="site-subtitle">{{ site.subtitle | escape_once | strip }}</span>{% endif %}
+        </a>
+        <ul class="visible-links">
+          {%- for link in site.data.navigation.main -%}
+            <li class="masthead__menu-item">
+              <a
+                href="{{ link.url | relative_url }}"
+                {% if link.description %} title="{{ link.description }}"{% endif %}
+                {% if link.target %} target="{{ link.target }}"{% endif %}
+              >{{ link.title }}</a>
+            </li>
+          {%- endfor -%}
+        </ul>
+        {% include a11y/settings-menu.html %}
+        {% if site.search == true %}
+        <button class="search__toggle" type="button">
+          <span class="visually-hidden">{{ site.data.ui-text[site.locale].search_label | default: "Toggle search" }}</span>
+          <i class="fas fa-search"></i>
+        </button>
+        {% endif %}
+        <button class="greedy-nav__toggle hidden" type="button">
+          <span class="visually-hidden">{{ site.data.ui-text[site.locale].menu_label | default: "Toggle menu" }}</span>
+          <div class="navicon"></div>
+        </button>
+        <ul class="hidden-links hidden"></ul>
+      </nav>
+    </div>
+  </div>
+</div>

--- a/_includes/webchat/panel.html
+++ b/_includes/webchat/panel.html
@@ -41,11 +41,20 @@
         <div class="wc-panel-header-status" id="wcStatus" aria-live="polite">Ready</div>
       </div>
     </div>
-    <button type="button" class="wc-panel-close" id="wcClose" aria-label="Close Lab Assistant">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-        <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
-      </svg>
-    </button>
+    <div class="wc-panel-header-actions">
+      <button type="button" class="wc-panel-action" id="wcReset" aria-label="Reset conversation" title="Reset conversation">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <polyline points="1 4 1 10 7 10"/>
+          <polyline points="23 20 23 14 17 14"/>
+          <path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10M3.51 15a9 9 0 0 0 14.85 3.36L23 14"/>
+        </svg>
+      </button>
+      <button type="button" class="wc-panel-action wc-panel-close" id="wcClose" aria-label="Close Lab Assistant">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+        </svg>
+      </button>
+    </div>
   </div>
 
   <!-- Body (WebChat renders here — transcript only, no sendbox) -->

--- a/_includes/webchat/panel.html
+++ b/_includes/webchat/panel.html
@@ -8,39 +8,41 @@
     var s = JSON.parse(raw);
     if (s && s.schemaVersion === 1 && s.tokenExpiresAt > Date.now() && s.isOpen) {
       document.documentElement.classList.add('wc-restore');
+      document.documentElement.setAttribute('data-panel-open', '');
     }
   } catch (e) {}
 })();
 </script>
 
-<!-- Chat tag (pull handle) -->
-<div class="wc-tag" id="wcTag" role="button" tabindex="0" aria-label="Open chat assistant">
-  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+<!-- Chat tag (pull handle). Native <button> — gets free keyboard handling
+     and focus semantics without the manual Enter/Space listener. -->
+<button type="button" class="wc-tag" id="wcTag" aria-label="Open Lab Assistant chat" aria-expanded="false" aria-controls="wcPanel">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
     <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
   </svg>
   <span class="wc-tag-label">Lab Assistant</span>
-</div>
+</button>
 
-<!-- Overlay -->
-<div class="wc-overlay" id="wcOverlay"></div>
+<!-- Overlay (script strips this from the DOM on init; see script.html:176) -->
+<div class="wc-overlay" id="wcOverlay" aria-hidden="true"></div>
 
 <!-- Chat panel -->
-<div class="wc-panel" id="wcPanel" role="complementary" aria-label="Chat assistant">
+<div class="wc-panel" id="wcPanel" role="dialog" aria-modal="false" aria-labelledby="wcPanelTitle" aria-hidden="true">
   <!-- Header -->
   <div class="wc-panel-header">
     <div class="wc-panel-header-left">
       <div class="wc-panel-header-icon">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
           <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
         </svg>
       </div>
       <div>
-        <div class="wc-panel-header-title">{{ site.data.webchat.botName | default: "Lab Assistant" }}</div>
+        <div class="wc-panel-header-title" id="wcPanelTitle">{{ site.data.webchat.botName | default: "Lab Assistant" }}</div>
         <div class="wc-panel-header-status" id="wcStatus" aria-live="polite">Ready</div>
       </div>
     </div>
-    <button class="wc-panel-close" id="wcClose" aria-label="Close chat">
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <button type="button" class="wc-panel-close" id="wcClose" aria-label="Close Lab Assistant">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
         <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
       </svg>
     </button>
@@ -51,12 +53,12 @@
     <div class="wc-panel-loading" id="wcLoading" style="display: none;"></div>
     <div class="wc-panel-error" id="wcError" style="display: none;" aria-live="assertive">
       <span>Could not connect to the assistant.</span>
-      <button id="wcRetry">Try again</button>
+      <button type="button" id="wcRetry">Try again</button>
     </div>
   </div>
 
   <!-- Typing indicator -->
-  <div class="wc-typing" id="wcTyping">
+  <div class="wc-typing" id="wcTyping" aria-hidden="true">
     <div class="wc-typing-dots">
       <span></span><span></span><span></span>
     </div>
@@ -64,10 +66,11 @@
 
   <!-- Custom send box -->
   <div class="wc-sendbox">
+    <label for="wcSendInput" class="visually-hidden">Message Lab Assistant</label>
     <div class="wc-sendbox-inner">
       <input type="text" id="wcSendInput" class="wc-sendbox-input" placeholder="Ask about labs, setup, or workshops..." autocomplete="off" />
-      <button id="wcSendBtn" class="wc-sendbox-btn" aria-label="Send message">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <button type="button" id="wcSendBtn" class="wc-sendbox-btn" aria-label="Send message">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
           <path d="M5 12h14M12 5l7 7-7 7"/>
         </svg>
       </button>

--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -250,7 +250,18 @@
     chatReady = false;
     chatInitializing = false;
     fallingBack = false;
-    body.innerHTML = '';
+
+    // Replace the host element entirely so renderWebChat mounts a fresh
+    // React tree. Just clearing innerHTML leaves React's _reactRootContainer
+    // on the element, which causes renderWebChat to do an update rather
+    // than a full remount — the old store/directLine stay wired up and
+    // the bot's fresh-conversation greeting never makes it to the visible
+    // transcript.
+    var parent = body.parentNode;
+    var fresh = body.cloneNode(false);
+    parent.replaceChild(fresh, body);
+    body = fresh;
+
     status.textContent = 'Connecting...';
     initChat();
   }

--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -16,6 +16,7 @@
   var overlay = document.getElementById('wcOverlay');
   var panel = document.getElementById('wcPanel');
   var closeBtn = document.getElementById('wcClose');
+  var resetBtn = document.getElementById('wcReset');
   var body = document.getElementById('wcBody');
   var loading = document.getElementById('wcLoading');
   var error = document.getElementById('wcError');
@@ -231,6 +232,30 @@
   // No manual Enter/Space handler: #wcTag is now a native <button>, which
   // activates on Enter/Space via the user-agent.
   closeBtn.addEventListener('click', close);
+
+  // --- Reset conversation ---
+  // Tears down the current token + transcript + watermark, then calls
+  // initChat() with no resumeState so a fresh token is fetched from the
+  // token endpoint. The bot's greeting will fire for the new conversation
+  // because initChat dispatches 'startConversation' when resumeState is
+  // absent. Focus stays on the chat input so the user can type immediately.
+  function resetConversation() {
+    clearPersistedState();
+    currentToken = null;
+    currentTokenExpiresAt = 0;
+    lastWatermark = null;
+    recentActivities = [];
+    replayedActivityIds = null;
+    chatStore = null;
+    chatReady = false;
+    chatInitializing = false;
+    fallingBack = false;
+    body.innerHTML = '';
+    status.textContent = 'Connecting...';
+    initChat();
+  }
+
+  resetBtn.addEventListener('click', resetConversation);
 
   document.addEventListener('keydown', function (e) {
     if (e.key === 'Escape' && isOpen) close();

--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -497,24 +497,13 @@
     });
   });
 
-  // Re-render WebChat when the theme changes so bot bubbles + transcript
-  // background adopt the new palette. Watermark-based resume keeps the
-  // transcript visible across the re-render.
-  var themeObserver = new MutationObserver(function (muts) {
-    for (var i = 0; i < muts.length; i++) {
-      if (muts[i].attributeName === 'data-theme') {
-        if (chatReady && currentToken && currentTokenExpiresAt > Date.now()) {
-          flushPersistState();
-          var resumeFrom = buildStateSnapshot();
-          chatInitializing = false;
-          chatReady = false;
-          replayedActivityIds = null;
-          initChat(resumeFrom);
-        }
-        break;
-      }
-    }
-  });
-  themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+  // Note: theme changes do NOT re-initialize the chat. The user's conversation
+  // (token + watermark + transcript) survives theme toggles. Most WebChat
+  // surfaces (transcript bg, bubble bg/fg, links, suggested actions) are
+  // re-skinned at runtime via CSS custom properties in the accompanying
+  // styles.html. The few colors that WebChat bakes into its internal DOM at
+  // init (timestamp text, focus rings on internal controls) will stay at the
+  // theme that was active when the chat first mounted — they refresh on the
+  // next page load.
 })();
 </script>

--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -179,6 +179,9 @@
     isOpen = true;
     panel.classList.add('wc-panel--open');
     tag.classList.add('wc-tag--hidden');
+    document.documentElement.setAttribute('data-panel-open', '');
+    tag.setAttribute('aria-expanded', 'true');
+    panel.setAttribute('aria-hidden', 'false');
     panel.addEventListener('keydown', handleFocusTrap);
     if (!chatInitializing && !chatReady) initChat();
     else if (chatReady) sendInput.focus();
@@ -189,15 +192,17 @@
     isOpen = false;
     panel.classList.remove('wc-panel--open');
     tag.classList.remove('wc-tag--hidden');
+    document.documentElement.removeAttribute('data-panel-open');
+    tag.setAttribute('aria-expanded', 'false');
+    panel.setAttribute('aria-hidden', 'true');
     panel.removeEventListener('keydown', handleFocusTrap);
     tag.focus();
     persistState();
   }
 
   tag.addEventListener('click', open);
-  tag.addEventListener('keydown', function (e) {
-    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
-  });
+  // No manual Enter/Space handler: #wcTag is now a native <button>, which
+  // activates on Enter/Space via the user-agent.
   closeBtn.addEventListener('click', close);
 
   document.addEventListener('keydown', function (e) {
@@ -460,6 +465,9 @@
       isOpen = true;
       panel.classList.add('wc-panel--open');
       tag.classList.add('wc-tag--hidden');
+      document.documentElement.setAttribute('data-panel-open', '');
+      tag.setAttribute('aria-expanded', 'true');
+      panel.setAttribute('aria-hidden', 'false');
       panel.addEventListener('keydown', handleFocusTrap);
       initChat(persistedState);
     }

--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -428,6 +428,35 @@
 
         timestampColor: tok('--color-fg-placeholder', '#a19f9d'),
         groupTimestamp: 30000,
+
+        // Adaptive Cards HostConfig — inline colors the SDK paints into
+        // .ac-textRun/.ac-textBlock come from here. Populate from CSS tokens
+        // so new cards render with the active theme out of the box.
+        adaptiveCardsHostConfig: {
+          fontFamily: "'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
+          containerStyles: {
+            default: {
+              backgroundColor: tok('--bubble-bot-bg', '#00000010'),
+              foregroundColors: {
+                default:   { default: tok('--color-fg-strong', '#201f1e'), subtle: tok('--color-fg-muted', '#605e5c') },
+                dark:      { default: tok('--color-fg-strong', '#201f1e'), subtle: tok('--color-fg-muted', '#605e5c') },
+                light:     { default: tok('--color-fg-strong', '#201f1e'), subtle: tok('--color-fg-muted', '#605e5c') },
+                accent:    { default: tok('--color-accent', '#0078d4'),    subtle: tok('--color-accent-hover', '#106ebe') },
+                good:      { default: tok('--color-success', '#0e700e'),   subtle: tok('--color-success', '#0e700e') },
+                warning:   { default: tok('--color-danger', '#c4314b'),    subtle: tok('--color-danger', '#c4314b') },
+                attention: { default: tok('--color-danger', '#c4314b'),    subtle: tok('--color-danger', '#c4314b') },
+              },
+            },
+            emphasis: {
+              backgroundColor: tok('--color-bg-elevated', '#f3f2f1'),
+              foregroundColors: {
+                default:   { default: tok('--color-fg-strong', '#201f1e'), subtle: tok('--color-fg-muted', '#605e5c') },
+                accent:    { default: tok('--color-accent', '#0078d4'),    subtle: tok('--color-accent-hover', '#106ebe') },
+                attention: { default: tok('--color-danger', '#c4314b'),    subtle: tok('--color-danger', '#c4314b') },
+              },
+            },
+          },
+        },
       };
 
       // Clear any prior mount before rendering

--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -367,8 +367,16 @@
 
       chatStore = store;
 
+      // Resolve token value from CSS at render time so WebChat's internal
+      // styling follows the active theme (data-theme on <html>).
+      var styleRoot = document.documentElement;
+      function tok(name, fallback) {
+        var v = getComputedStyle(styleRoot).getPropertyValue(name).trim();
+        return v || fallback;
+      }
+
       var styleOptions = {
-        backgroundColor: '#faf9f8',
+        backgroundColor: tok('--color-bg-subtle', '#faf9f8'),
         rootHeight: '100%',
         rootWidth: '100%',
 
@@ -379,26 +387,26 @@
         showAvatarInGroup: false,
         avatarSize: 0,
 
-        bubbleBackground: 'rgba(0, 0, 0, 0.04)',
+        bubbleBackground: tok('--bubble-bot-bg', 'rgba(0, 0, 0, 0.04)'),
         bubbleBorderColor: 'transparent',
         bubbleBorderRadius: 14,
-        bubbleTextColor: '#3b3a39',
+        bubbleTextColor: tok('--color-fg-body', '#3b3a39'),
 
-        bubbleFromUserBackground: 'rgba(0, 120, 212, 0.08)',
+        bubbleFromUserBackground: tok('--color-user-bubble-bg', 'rgba(0, 120, 212, 0.08)'),
         bubbleFromUserBorderColor: 'transparent',
         bubbleFromUserBorderRadius: 14,
-        bubbleFromUserTextColor: '#1a3a5c',
+        bubbleFromUserTextColor: tok('--color-user-bubble-fg', '#1a3a5c'),
 
         hideSendBox: true,
         hideUploadButton: true,
 
-        suggestedActionBackgroundColor: '#ffffff',
-        suggestedActionBorderColor: '#0078d4',
-        suggestedActionTextColor: '#0078d4',
+        suggestedActionBackgroundColor: tok('--color-bg', '#ffffff'),
+        suggestedActionBorderColor: tok('--color-accent', '#0078d4'),
+        suggestedActionTextColor: tok('--color-accent', '#0078d4'),
         suggestedActionBorderRadius: 100,
         suggestedActionHeight: 32,
 
-        timestampColor: '#a19f9d',
+        timestampColor: tok('--color-fg-placeholder', '#a19f9d'),
         groupTimestamp: 30000,
       };
 
@@ -488,5 +496,25 @@
       document.documentElement.classList.remove('wc-restore');
     });
   });
+
+  // Re-render WebChat when the theme changes so bot bubbles + transcript
+  // background adopt the new palette. Watermark-based resume keeps the
+  // transcript visible across the re-render.
+  var themeObserver = new MutationObserver(function (muts) {
+    for (var i = 0; i < muts.length; i++) {
+      if (muts[i].attributeName === 'data-theme') {
+        if (chatReady && currentToken && currentTokenExpiresAt > Date.now()) {
+          flushPersistState();
+          var resumeFrom = buildStateSnapshot();
+          chatInitializing = false;
+          chatReady = false;
+          replayedActivityIds = null;
+          initChat(resumeFrom);
+        }
+        break;
+      }
+    }
+  });
+  themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
 })();
 </script>

--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -175,6 +175,11 @@
   // Remove overlay — lab assistant should not block page interaction
   if (overlay && overlay.parentNode) overlay.parentNode.removeChild(overlay);
 
+  // Start inert — panel is aria-hidden=true initially. `inert` pulls focusable
+  // children out of the tab order so keyboard users don't Tab into the hidden
+  // panel. Toggled in open()/close().
+  panel.inert = true;
+
   function open() {
     isOpen = true;
     panel.classList.add('wc-panel--open');
@@ -182,6 +187,7 @@
     document.documentElement.setAttribute('data-panel-open', '');
     tag.setAttribute('aria-expanded', 'true');
     panel.setAttribute('aria-hidden', 'false');
+    panel.inert = false;
     panel.addEventListener('keydown', handleFocusTrap);
     if (!chatInitializing && !chatReady) initChat();
     else if (chatReady) sendInput.focus();
@@ -195,6 +201,7 @@
     document.documentElement.removeAttribute('data-panel-open');
     tag.setAttribute('aria-expanded', 'false');
     panel.setAttribute('aria-hidden', 'true');
+    panel.inert = true;
     panel.removeEventListener('keydown', handleFocusTrap);
     tag.focus();
     persistState();
@@ -468,6 +475,7 @@
       document.documentElement.setAttribute('data-panel-open', '');
       tag.setAttribute('aria-expanded', 'true');
       panel.setAttribute('aria-hidden', 'false');
+      panel.inert = false;
       panel.addEventListener('keydown', handleFocusTrap);
       initChat(persistedState);
     }

--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -121,21 +121,41 @@
     persistState();
   }
 
-  // --- Masthead offset: keep panel below the site header at all widths ---
+  // --- Masthead + footer offsets: keep panel inside the "chrome sandwich" ---
+  // The panel is position: fixed and would normally occupy the full right
+  // column between the top and bottom edges of the viewport. We nudge its
+  // top below the masthead (so nav stays reachable) and its bottom above
+  // the visible portion of the site footer (so the footer links are never
+  // obscured).
 
-  var mastheadResizeFrame = null;
+  var chromeOffsetFrame = null;
 
-  function applyMastheadOffset() {
-    mastheadResizeFrame = null;
+  function applyChromeOffsets() {
+    chromeOffsetFrame = null;
     var masthead = document.querySelector('.masthead');
-    var h = masthead ? Math.ceil(masthead.getBoundingClientRect().bottom) : 0;
-    document.documentElement.style.setProperty('--wc-panel-top', h + 'px');
+    var topPx = masthead ? Math.max(0, Math.ceil(masthead.getBoundingClientRect().bottom)) : 0;
+    document.documentElement.style.setProperty('--wc-panel-top', topPx + 'px');
+
+    var footer = document.querySelector('.page__footer') || document.getElementById('footer');
+    var bottomPx = 0;
+    if (footer) {
+      var rect = footer.getBoundingClientRect();
+      var vh = window.innerHeight || document.documentElement.clientHeight;
+      // Footer intrudes into the viewport by (vh - rect.top); clamp so the
+      // panel only shrinks when the footer is actually visible.
+      bottomPx = Math.max(0, Math.ceil(vh - rect.top));
+    }
+    document.documentElement.style.setProperty('--wc-panel-bottom', bottomPx + 'px');
   }
 
-  function scheduleMastheadOffset() {
-    if (mastheadResizeFrame) return;
-    mastheadResizeFrame = requestAnimationFrame(applyMastheadOffset);
+  function scheduleChromeOffsets() {
+    if (chromeOffsetFrame) return;
+    chromeOffsetFrame = requestAnimationFrame(applyChromeOffsets);
   }
+
+  // Back-compat aliases for earlier variable names used elsewhere in this file.
+  var applyMastheadOffset = applyChromeOffsets;
+  var scheduleMastheadOffset = scheduleChromeOffsets;
 
   // --- Sendbox disabled state ---
 
@@ -464,9 +484,10 @@
 
   // --- Restore session state on page load ---
 
-  applyMastheadOffset();
-  window.addEventListener('resize', scheduleMastheadOffset);
-  window.addEventListener('load', applyMastheadOffset);
+  applyChromeOffsets();
+  window.addEventListener('resize', scheduleChromeOffsets);
+  window.addEventListener('scroll', scheduleChromeOffsets, { passive: true });
+  window.addEventListener('load', applyChromeOffsets);
 
   window.addEventListener('pagehide', flushPersistState);
 

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -163,7 +163,14 @@ html.wc-restore .wc-tag {
   letter-spacing: 0.01em;
 }
 
-.wc-panel-close {
+.wc-panel-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.wc-panel-action {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -178,17 +185,17 @@ html.wc-restore .wc-tag {
   flex-shrink: 0;
 }
 
-.wc-panel-close:hover {
+.wc-panel-action:hover {
   background: var(--color-bg-elevated, #f3f2f1);
   color: var(--color-fg-strong, #323130);
 }
 
-.wc-panel-close:focus-visible {
+.wc-panel-action:focus-visible {
   outline: none;
   box-shadow: var(--focus-ring, 0 0 0 2px #fff, 0 0 0 4px #0078d4);
 }
 
-.wc-panel-close svg { width: 16px; height: 16px; }
+.wc-panel-action svg { width: 16px; height: 16px; }
 
 /* --- WebChat body (transcript) --- */
 .wc-panel-body {

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -79,7 +79,9 @@
   position: fixed;
   top: var(--wc-panel-top, 0);
   right: 0;
-  bottom: 0;
+  /* --wc-panel-bottom tracks how far the site footer has scrolled into
+     view, so the panel never overlaps footer links on low-res displays. */
+  bottom: var(--wc-panel-bottom, 0);
   width: 400px;
   max-width: 90vw;
   z-index: 99992;

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -1,6 +1,11 @@
 <style>
 /* ============================================
    WebChat Side Panel — Air Theme
+
+   Every color resolves through a CSS custom property defined in
+   assets/css/_tokens.scss. Hex fallbacks after the comma preserve the
+   current light-theme appearance even if the token layer fails to load
+   (e.g. a build miss or stylesheet request failure).
    ============================================ */
 
 /* --- Tag (pull handle) --- */
@@ -15,26 +20,31 @@
   gap: 6px;
   writing-mode: vertical-lr;
   text-orientation: mixed;
-  background: #fff;
-  color: #605e5c;
+  background: var(--color-bg, #fff);
+  color: var(--color-fg-muted, #605e5c);
   font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-size: 0.78rem;
   font-weight: 600;
   letter-spacing: 0.03em;
   padding: 14px 10px;
   border-radius: 10px 0 0 10px;
-  border: 1px solid #e1dfdd;
+  border: 1px solid var(--color-border, #e1dfdd);
   border-right: none;
   cursor: pointer;
-  box-shadow: -2px 0 12px rgba(0, 0, 0, 0.04);
+  box-shadow: var(--shadow-tag, -2px 0 12px rgba(0, 0, 0, 0.04));
   transition: background 0.2s, color 0.2s, box-shadow 0.2s, right 0.35s cubic-bezier(0.4, 0, 0.2, 1);
   user-select: none;
 }
 
 .wc-tag:hover {
-  background: #f3f2f1;
-  color: #323130;
-  box-shadow: -3px 0 16px rgba(0, 0, 0, 0.08);
+  background: var(--color-bg-elevated, #f3f2f1);
+  color: var(--color-fg-strong, #323130);
+  box-shadow: var(--shadow-tag-hover, -3px 0 16px rgba(0, 0, 0, 0.08));
+}
+
+.wc-tag:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring, 0 0 0 2px #fff, 0 0 0 4px #0078d4);
 }
 
 .wc-tag svg { width: 18px; height: 18px; flex-shrink: 0; }
@@ -50,7 +60,7 @@
 .wc-overlay {
   position: fixed;
   inset: 0;
-  background: rgba(15, 27, 45, 0.06);
+  background: var(--overlay-bg, rgba(15, 27, 45, 0.06));
   z-index: 99991;
   opacity: 0;
   pointer-events: none;
@@ -75,11 +85,11 @@
   z-index: 99992;
   display: flex;
   flex-direction: column;
-  background: #fff;
-  border-left: 1px solid #d2d0ce;
-  box-shadow:
+  background: var(--color-bg, #fff);
+  border-left: 1px solid var(--color-border-strong, #d2d0ce);
+  box-shadow: var(--shadow-panel,
     -8px 0 40px rgba(0, 0, 0, 0.08),
-    -1px 0 0 rgba(0, 0, 0, 0.04);
+    -1px 0 0 rgba(0, 0, 0, 0.04));
   transform: translateX(100%);
   transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
 }
@@ -103,9 +113,9 @@ html.wc-restore .wc-tag {
   align-items: center;
   justify-content: space-between;
   padding: 16px 18px;
-  border-bottom: 1px solid #eae8e6;
+  border-bottom: 1px solid var(--color-divider, #eae8e6);
   flex-shrink: 0;
-  background: #fff;
+  background: var(--color-bg, #fff);
 }
 
 .wc-panel-header-left {
@@ -118,32 +128,34 @@ html.wc-restore .wc-tag {
   width: 32px;
   height: 32px;
   border-radius: 10px;
-  background: linear-gradient(135deg, #0078d4 0%, #005a9e 100%);
+  background: linear-gradient(135deg,
+    var(--color-accent, #0078d4) 0%,
+    var(--color-accent-active, #005a9e) 100%);
   display: flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  box-shadow: 0 2px 8px rgba(0, 120, 212, 0.25);
+  box-shadow: 0 2px 8px var(--color-accent-tint-3, rgba(0, 120, 212, 0.25));
 }
 
 .wc-panel-header-icon svg {
   width: 17px;
   height: 17px;
-  color: #fff;
+  color: var(--color-accent-on, #fff);
 }
 
 .wc-panel-header-title {
   font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-size: 0.92rem;
   font-weight: 600;
-  color: #201f1e;
+  color: var(--color-fg, #201f1e);
   line-height: 1.2;
 }
 
 .wc-panel-header-status {
   font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-size: 0.68rem;
-  color: #a19f9d;
+  color: var(--color-fg-disabled, #757371);
   font-weight: 500;
   margin-top: 1px;
   letter-spacing: 0.01em;
@@ -158,15 +170,20 @@ html.wc-restore .wc-tag {
   border-radius: 8px;
   border: none;
   background: transparent;
-  color: #a19f9d;
+  color: var(--color-fg-disabled, #757371);
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
   flex-shrink: 0;
 }
 
 .wc-panel-close:hover {
-  background: #f3f2f1;
-  color: #323130;
+  background: var(--color-bg-elevated, #f3f2f1);
+  color: var(--color-fg-strong, #323130);
+}
+
+.wc-panel-close:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring, 0 0 0 2px #fff, 0 0 0 4px #0078d4);
 }
 
 .wc-panel-close svg { width: 16px; height: 16px; }
@@ -176,7 +193,7 @@ html.wc-restore .wc-tag {
   flex: 1;
   overflow: hidden;
   position: relative;
-  background: #faf9f8;
+  background: var(--color-bg-subtle, #faf9f8);
 }
 
 .wc-panel-body > div { height: 100%; }
@@ -193,14 +210,14 @@ html.wc-restore .wc-tag {
   gap: 14px;
   padding: 32px;
   text-align: center;
-  color: #605e5c;
+  color: var(--color-fg-muted, #605e5c);
   font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-size: 0.84rem;
 }
 
 .wc-panel-error button {
-  background: #0078d4;
-  color: #fff;
+  background: var(--color-accent, #0078d4);
+  color: var(--color-accent-on, #fff);
   border: none;
   padding: 9px 20px;
   border-radius: 8px;
@@ -211,7 +228,12 @@ html.wc-restore .wc-tag {
   transition: background 0.15s;
 }
 
-.wc-panel-error button:hover { background: #106ebe; }
+.wc-panel-error button:hover { background: var(--color-accent-hover, #106ebe); }
+
+.wc-panel-error button:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring, 0 0 0 2px #fff, 0 0 0 4px #0078d4);
+}
 
 /* ===========================================
    Typing Indicator
@@ -242,7 +264,7 @@ html.wc-restore .wc-tag {
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: #b3b0ad;
+  background: var(--color-fg-placeholder, #767472);
   animation: wc-dot-pulse 1.4s ease-in-out infinite;
 }
 
@@ -272,24 +294,27 @@ html.wc-restore .wc-tag {
 .wc-sendbox {
   flex-shrink: 0;
   padding: 12px 16px 16px;
-  background: #fff;
-  border-top: 1px solid #eae8e6;
+  background: var(--color-bg, #fff);
+  border-top: 1px solid var(--color-divider, #eae8e6);
 }
 
 .wc-sendbox-inner {
   display: flex;
   align-items: center;
   gap: 6px;
-  background: #f0efed;
+  background: var(--color-bg-input, #f0efed);
   border: none;
   border-radius: 24px;
   padding: 4px 5px 4px 18px;
   transition: background 0.2s ease, box-shadow 0.2s ease;
 }
 
+/* Focus state is owned by the wrapper so the focus ring encloses the whole
+   pill (input + send button). Visible for both mouse and keyboard users. */
 .wc-sendbox-inner:focus-within {
-  background: #eae9e7;
-  box-shadow: 0 0 0 2px rgba(0, 120, 212, 0.12);
+  background: var(--color-bg-input-hover, #eae9e7);
+  box-shadow: 0 0 0 2px var(--color-accent-tint-2, rgba(0, 120, 212, 0.25)),
+              0 0 0 4px var(--color-accent, #0078d4);
 }
 
 .wc-sendbox-input,
@@ -299,10 +324,13 @@ html.wc-restore .wc-tag {
   border-radius: 0 !important;
   background: transparent !important;
   box-shadow: none !important;
+  /* No outline on the inner input — the focus ring lives on
+     .wc-sendbox-inner:focus-within above. Keyboard users still see a visible
+     indicator because the wrapper's focus-within triggers on input focus. */
   outline: none !important;
   font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-size: 0.8rem;
-  color: #201f1e;
+  color: var(--color-fg, #201f1e);
   padding: 9px 0 !important;
   margin: 0 !important;
   line-height: 1.4;
@@ -312,14 +340,8 @@ html.wc-restore .wc-tag {
 }
 
 .wc-sendbox-input::placeholder {
-  color: #b3b0ad;
+  color: var(--color-fg-placeholder, #767472);
   font-weight: 400;
-}
-
-.wc-sendbox-input:focus {
-  border: none !important;
-  box-shadow: none !important;
-  outline: none !important;
 }
 
 .wc-sendbox-btn {
@@ -328,8 +350,10 @@ html.wc-restore .wc-tag {
   min-width: 34px;
   border-radius: 50%;
   border: none;
-  background: linear-gradient(135deg, #0078d4 0%, #005a9e 100%);
-  color: #fff;
+  background: linear-gradient(135deg,
+    var(--color-accent, #0078d4) 0%,
+    var(--color-accent-active, #005a9e) 100%);
+  color: var(--color-accent-on, #fff);
   cursor: pointer;
   display: flex;
   align-items: center;
@@ -337,18 +361,32 @@ html.wc-restore .wc-tag {
   padding: 0;
   flex-shrink: 0;
   transition: all 0.15s ease;
-  box-shadow: 0 2px 6px rgba(0, 120, 212, 0.3);
+  box-shadow: var(--shadow-send, 0 2px 6px rgba(0, 120, 212, 0.30));
 }
 
 .wc-sendbox-btn:hover {
-  background: linear-gradient(135deg, #106ebe 0%, #004578 100%);
-  box-shadow: 0 3px 10px rgba(0, 120, 212, 0.35);
+  background: linear-gradient(135deg,
+    var(--color-accent-hover, #106ebe) 0%,
+    var(--color-accent-deep, #004578) 100%);
+  box-shadow: var(--shadow-send-hover, 0 3px 10px rgba(0, 120, 212, 0.35));
   transform: translateY(-1px);
 }
 
 .wc-sendbox-btn:active {
   transform: translateY(0) scale(0.96);
-  box-shadow: 0 1px 3px rgba(0, 120, 212, 0.25);
+  box-shadow: var(--shadow-send-active, 0 1px 3px rgba(0, 120, 212, 0.25));
+}
+
+.wc-sendbox-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring, 0 0 0 2px #fff, 0 0 0 4px #0078d4);
+}
+
+.wc-sendbox-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
 }
 
 .wc-sendbox-btn svg {
@@ -362,7 +400,7 @@ html.wc-restore .wc-tag {
   text-align: center;
   font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-size: 0.66rem;
-  color: #c8c6c4;
+  color: var(--color-fg-hint, #605e5c);
   margin-top: 8px;
   letter-spacing: 0.01em;
 }
@@ -372,39 +410,36 @@ html.wc-restore .wc-tag {
    =================================== */
 
 .wc-panel-body .webchat__basic-transcript {
-  background: #faf9f8 !important;
+  background: var(--color-bg-subtle, #faf9f8) !important;
 }
 
 /* Bot bubble */
 .wc-panel-body .webchat__bubble:not(.webchat__bubble--from-user) .webchat__bubble__content {
-  background: rgba(0, 0, 0, 0.04) !important;
+  background: var(--bubble-bot-bg, rgba(0, 0, 0, 0.04)) !important;
   border: none !important;
   border-radius: 14px 14px 14px 4px !important;
-  color: #3b3a39 !important;
+  color: var(--color-fg-body, #3b3a39) !important;
 }
 
 /* User bubble */
 .wc-panel-body .webchat__bubble--from-user .webchat__bubble__content {
-  background: rgba(0, 120, 212, 0.08) !important;
+  background: var(--color-user-bubble-bg, rgba(0, 120, 212, 0.08)) !important;
   border: none !important;
   border-radius: 14px 14px 4px 14px !important;
-  color: #1a3a5c !important;
+  color: var(--color-user-bubble-fg, #1a3a5c) !important;
 }
 
 /* Links */
-.wc-panel-body .webchat__bubble:not(.webchat__bubble--from-user) a {
-  color: #0078d4 !important;
-}
-
+.wc-panel-body .webchat__bubble:not(.webchat__bubble--from-user) a,
 .wc-panel-body .webchat__bubble--from-user a {
-  color: #0078d4 !important;
+  color: var(--color-accent, #0078d4) !important;
 }
 
 /* Suggested actions */
 .wc-panel-body .webchat__suggested-action__button {
-  background: #fff !important;
-  border: 1px solid #0078d4 !important;
-  color: #0078d4 !important;
+  background: var(--color-bg, #fff) !important;
+  border: 1px solid var(--color-accent, #0078d4) !important;
+  color: var(--color-accent, #0078d4) !important;
   border-radius: 100px !important;
   font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
   font-size: 0.8rem !important;
@@ -415,8 +450,8 @@ html.wc-restore .wc-tag {
 }
 
 .wc-panel-body .webchat__suggested-action__button:hover {
-  background: #0078d4 !important;
-  color: #fff !important;
+  background: var(--color-accent, #0078d4) !important;
+  color: var(--color-accent-on, #fff) !important;
 }
 
 /* Hide default typing indicator — we use our own */
@@ -444,13 +479,13 @@ html.wc-restore .wc-tag {
 /* Timestamp */
 .wc-panel-body .webchat__stacked-layout__status {
   font-size: 0.65rem !important;
-  color: #b3b0ad !important;
+  color: var(--color-fg-placeholder, #767472) !important;
 }
 
 /* Scrollbar */
 .wc-panel-body ::-webkit-scrollbar { width: 5px; }
 .wc-panel-body ::-webkit-scrollbar-track { background: transparent; }
-.wc-panel-body ::-webkit-scrollbar-thumb { background: #d2d0ce; border-radius: 3px; }
+.wc-panel-body ::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb, #d2d0ce); border-radius: 3px; }
 
 /* ===================================
    Adaptive Cards — Air Theme
@@ -459,17 +494,17 @@ html.wc-restore .wc-tag {
 .wc-panel-body a.ac-anchor,
 .wc-panel-body a.ac-anchor:link,
 .wc-panel-body a.ac-anchor:visited {
-  color: #0078d4 !important;
+  color: var(--color-accent, #0078d4) !important;
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
-.wc-panel-body a.ac-anchor:hover { color: #106ebe !important; }
+.wc-panel-body a.ac-anchor:hover { color: var(--color-accent-hover, #106ebe) !important; }
 
 .wc-panel-body .ac-pushButton {
-  background: #fff !important;
-  color: #323130 !important;
-  border: 1px solid #e1dfdd !important;
+  background: var(--color-bg, #fff) !important;
+  color: var(--color-fg-strong, #323130) !important;
+  border: 1px solid var(--color-border, #e1dfdd) !important;
   border-radius: 8px !important;
   padding: 8px 14px !important;
   font-size: 13px !important;
@@ -480,25 +515,25 @@ html.wc-restore .wc-tag {
 }
 
 .wc-panel-body .ac-pushButton:hover {
-  background: #f3f2f1 !important;
-  border-color: #c8c6c4 !important;
+  background: var(--color-bg-elevated, #f3f2f1) !important;
+  border-color: var(--color-border-strong, #d2d0ce) !important;
 }
 
-.wc-panel-body .ac-pushButton.style-positive { color: #0e700e !important; border-color: #a7e3a5 !important; }
-.wc-panel-body .ac-pushButton.style-destructive { color: #c4314b !important; border-color: #f1bbbc !important; }
+.wc-panel-body .ac-pushButton.style-positive { color: var(--color-success, #0e700e) !important; border-color: var(--color-success-border, #a7e3a5) !important; }
+.wc-panel-body .ac-pushButton.style-destructive { color: var(--color-danger, #c4314b) !important; border-color: var(--color-danger-border, #f1bbbc) !important; }
 
 .wc-panel-body .ac-input {
   font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
   font-size: 13px !important;
-  color: #323130 !important;
-  background: #fff !important;
-  border: 1px solid #e1dfdd !important;
+  color: var(--color-fg-strong, #323130) !important;
+  background: var(--color-bg, #fff) !important;
+  border: 1px solid var(--color-border, #e1dfdd) !important;
   border-radius: 8px !important;
   padding: 8px 12px !important;
 }
 
-.wc-panel-body .ac-input:focus { outline: none; border-color: #0078d4 !important; }
-.wc-panel-body .ac-textBlock { line-height: 1.45; color: #323130; }
+.wc-panel-body .ac-input:focus { outline: none; border-color: var(--color-accent, #0078d4) !important; box-shadow: 0 0 0 2px var(--color-accent-tint-2, rgba(0,120,212,0.12)); }
+.wc-panel-body .ac-textBlock { line-height: 1.45; color: var(--color-fg-strong, #323130); }
 .wc-panel-body .ac-image { border-radius: 8px; }
 .wc-panel-body .ac-actionSet { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 6px; }
 

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -561,14 +561,31 @@ html.wc-restore .wc-tag {
   box-shadow: 0 0 0 2px var(--color-accent-tint-2, rgba(0,120,212,0.25)) !important;
 }
 
-/* Force a visible label color in every palette. Adaptive Cards sometimes
-   renders its own inline color on .ac-textBlock descendants — raise
-   specificity and keep !important to beat it. */
+/* Force a visible label color in every palette. Adaptive Cards SDK writes
+   an inline `color: rgb(…)` on every .ac-textRun / .ac-textBlock based on
+   its HostConfig (locked to Light values at render time). Override with
+   !important so dark/HC labels are readable. The companion HostConfig
+   injected via styleOptions (see script.html) preserves semantic colors
+   (accent, attention, good, warning) via distinct CSS overrides below. */
 .wc-panel-body .ac-textBlock,
 .wc-panel-body .ac-textBlock span,
-.wc-panel-body .ac-textBlock p {
+.wc-panel-body .ac-textBlock p,
+.wc-panel-body .ac-richTextBlock,
+.wc-panel-body .ac-richTextBlock .ac-textRun,
+.wc-panel-body .ac-textRun,
+.wc-panel-body .ac-container .ac-textRun {
   line-height: 1.45;
-  color: var(--color-fg, #201f1e) !important;
+  color: var(--color-fg-strong, #201f1e) !important;
+}
+
+/* Keep semantic color runs readable: if Adaptive Cards emits an inline
+   color near the red "attention" spectrum, map to --color-danger so it
+   stays visible against dark bg. Using attribute-prefix matches the SDK's
+   default HostConfig value (#D13438). */
+.wc-panel-body .ac-textRun[style*="rgb(209, 52, 56)"],
+.wc-panel-body .ac-textRun[style*="#D13438"],
+.wc-panel-body .ac-textRun[style*="#d13438"] {
+  color: var(--color-danger, #c4314b) !important;
 }
 
 .wc-panel-body .ac-image { border-radius: 8px; }

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -329,7 +329,7 @@ html.wc-restore .wc-tag {
      indicator because the wrapper's focus-within triggers on input focus. */
   outline: none !important;
   font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  font-size: 0.8rem;
+  font-size: 0.95rem;
   color: var(--color-fg, #201f1e);
   padding: 9px 0 !important;
   margin: 0 !important;
@@ -442,7 +442,7 @@ html.wc-restore .wc-tag {
   color: var(--color-accent, #0078d4) !important;
   border-radius: 100px !important;
   font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
-  font-size: 0.8rem !important;
+  font-size: 0.9rem !important;
   font-weight: 500 !important;
   padding: 6px 16px !important;
   transition: all 0.15s ease !important;
@@ -464,13 +464,28 @@ html.wc-restore .wc-tag {
   display: none !important;
 }
 
-/* Message text */
+/* Message text — set base on the transcript container so every child
+   inherits via rem and follows the --font-scale root multiplier. Explicit
+   overrides on known WebChat text classes keep the cascade predictable
+   against WebChat's own emotion-injected rules. */
+.wc-panel-body .webchat__basic-transcript,
+.wc-panel-body .webchat__basic-transcript * {
+  font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
+}
+
+.wc-panel-body .webchat__basic-transcript {
+  font-size: 0.95rem !important;
+}
+
 .wc-panel-body .webchat__text-content,
 .wc-panel-body .webchat__text-content p,
+.wc-panel-body .webchat__render-markdown,
 .wc-panel-body .webchat__render-markdown p,
-.wc-panel-body .webchat__render-markdown li {
-  font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
-  font-size: 0.8rem !important;
+.wc-panel-body .webchat__render-markdown li,
+.wc-panel-body .webchat__bubble__content,
+.wc-panel-body .webchat__bubble__content p,
+.wc-panel-body .webchat__bubble__content li {
+  font-size: 0.95rem !important;
   font-weight: 400 !important;
   line-height: 1.55 !important;
   color: inherit !important;
@@ -478,7 +493,7 @@ html.wc-restore .wc-tag {
 
 /* Timestamp */
 .wc-panel-body .webchat__stacked-layout__status {
-  font-size: 0.65rem !important;
+  font-size: 0.75rem !important;
   color: var(--color-fg-placeholder, #767472) !important;
 }
 

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -526,14 +526,34 @@ html.wc-restore .wc-tag {
   font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif !important;
   font-size: 13px !important;
   color: var(--color-fg-strong, #323130) !important;
-  background: var(--color-bg, #fff) !important;
-  border: 1px solid var(--color-border, #e1dfdd) !important;
+  /* Use the elevated surface so inputs stand off from the bot bubble's bg
+     in dark mode (bg-elevated is lighter than bg, even inside the tint). */
+  background: var(--color-bg-elevated, #f3f2f1) !important;
+  border: 1px solid var(--color-border-strong, #d2d0ce) !important;
   border-radius: 8px !important;
   padding: 8px 12px !important;
 }
 
-.wc-panel-body .ac-input:focus { outline: none; border-color: var(--color-accent, #0078d4) !important; box-shadow: 0 0 0 2px var(--color-accent-tint-2, rgba(0,120,212,0.12)); }
-.wc-panel-body .ac-textBlock { line-height: 1.45; color: var(--color-fg-strong, #323130); }
+.wc-panel-body .ac-input::placeholder {
+  color: var(--color-fg-placeholder, #767472) !important;
+}
+
+.wc-panel-body .ac-input:focus {
+  outline: none;
+  border-color: var(--color-accent, #0078d4) !important;
+  box-shadow: 0 0 0 2px var(--color-accent-tint-2, rgba(0,120,212,0.25)) !important;
+}
+
+/* Force a visible label color in every palette. Adaptive Cards sometimes
+   renders its own inline color on .ac-textBlock descendants — raise
+   specificity and keep !important to beat it. */
+.wc-panel-body .ac-textBlock,
+.wc-panel-body .ac-textBlock span,
+.wc-panel-body .ac-textBlock p {
+  line-height: 1.45;
+  color: var(--color-fg, #201f1e) !important;
+}
+
 .wc-panel-body .ac-image { border-radius: 8px; }
 .wc-panel-body .ac-actionSet { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 6px; }
 

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -5,8 +5,11 @@ layout: single
 <style>
 .page__title, .page__meta { display: none; }
 .ws-hero {
-  background: linear-gradient(135deg, #0f1b2d 0%, #1a3a5c 50%, #0f2440 100%);
-  color: #fff;
+  background: linear-gradient(135deg,
+    var(--color-lab-grad-1) 0%,
+    var(--color-lab-grad-2) 50%,
+    var(--color-lab-grad-3) 100%);
+  color: var(--color-on-lab-header);
   padding: 2.5em 2em;
   border-radius: 10px;
   margin: -0.5em 0 2em;
@@ -20,7 +23,7 @@ layout: single
   right: -15%;
   width: 400px;
   height: 400px;
-  background: radial-gradient(circle, rgba(0,120,212,0.12) 0%, transparent 70%);
+  background: radial-gradient(circle, var(--color-lab-hero-glow) 0%, transparent 70%);
   pointer-events: none;
 }
 .ws-hero h2 {
@@ -30,7 +33,7 @@ layout: single
   letter-spacing: -0.01em;
   border: none;
   padding: 0;
-  color: #fff;
+  color: var(--color-on-lab-header);
 }
 .ws-hero p {
   font-size: 0.95em;
@@ -71,10 +74,11 @@ layout: single
 }
 
 .ws-lab-card {
-  border: 1px solid #e8e6e4;
+  border: 1px solid var(--color-border-subtle);
   border-radius: 8px;
   padding: 1em 1.2em;
-  background: #fff;
+  background: var(--color-bg);
+  color: var(--color-fg-strong);
   display: grid;
   grid-template-columns: 52px 1fr auto;
   gap: 0 1em;
@@ -82,15 +86,15 @@ layout: single
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 .ws-lab-card:hover {
-  border-color: #c8c6c4;
+  border-color: var(--color-border-strong);
   box-shadow: 0 2px 8px rgba(0,0,0,0.06);
 }
 
 .ws-lab-num {
   font-size: 0.72em;
   font-weight: 700;
-  color: #0078d4;
-  background: #deecf9;
+  color: var(--color-pill-blue-fg);
+  background: var(--color-pill-blue-bg);
   border-radius: 6px;
   padding: 0.35em 0;
   text-align: center;
@@ -105,7 +109,7 @@ layout: single
 .ws-lab-title {
   font-size: 0.92em;
   font-weight: 600;
-  color: #323130;
+  color: var(--color-fg-strong);
   margin: 0 0 0.25em;
   line-height: 1.35;
 }
@@ -114,11 +118,11 @@ layout: single
   text-decoration: none;
 }
 .ws-lab-title a:hover {
-  color: #0078d4;
+  color: var(--color-accent);
 }
 .ws-lab-desc {
   font-size: 0.8em;
-  color: #605e5c;
+  color: var(--color-fg-muted);
   line-height: 1.5;
   margin: 0;
   display: -webkit-box;
@@ -143,20 +147,20 @@ layout: single
   white-space: nowrap;
 }
 .ws-pill-duration {
-  background: #f3f2f1;
-  color: #605e5c;
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-muted);
 }
 .ws-pill-level-100 {
-  background: #e6f2e6;
-  color: #0e700e;
+  background: var(--color-pill-green-bg);
+  color: var(--color-pill-green-fg);
 }
 .ws-pill-level-200 {
-  background: #deecf9;
-  color: #004578;
+  background: var(--color-pill-blue-bg);
+  color: var(--color-pill-blue-fg);
 }
 .ws-pill-level-300 {
-  background: #f0e6fc;
-  color: #5b2d8e;
+  background: var(--color-pill-purple-bg);
+  color: var(--color-pill-purple-fg);
 }
 </style>
 

--- a/_layouts/workshop.html
+++ b/_layouts/workshop.html
@@ -5,8 +5,11 @@ layout: single
 <style>
 .page__title, .page__meta { display: none; }
 .ws-hero {
-  background: linear-gradient(135deg, #0f1b2d 0%, #1a3a5c 50%, #0f2440 100%);
-  color: #fff;
+  background: linear-gradient(135deg,
+    var(--color-lab-grad-1) 0%,
+    var(--color-lab-grad-2) 50%,
+    var(--color-lab-grad-3) 100%);
+  color: var(--color-on-lab-header);
   padding: 2.5em 2em;
   border-radius: 10px;
   margin: -0.5em 0 2em;
@@ -20,7 +23,7 @@ layout: single
   right: -15%;
   width: 400px;
   height: 400px;
-  background: radial-gradient(circle, rgba(0,120,212,0.12) 0%, transparent 70%);
+  background: radial-gradient(circle, var(--color-lab-hero-glow) 0%, transparent 70%);
   pointer-events: none;
 }
 .ws-hero h2 {
@@ -30,7 +33,7 @@ layout: single
   letter-spacing: -0.01em;
   border: none;
   padding: 0;
-  color: #fff;
+  color: var(--color-on-lab-header);
 }
 .ws-hero p {
   font-size: 0.95em;
@@ -71,10 +74,11 @@ layout: single
 }
 
 .ws-lab-card {
-  border: 1px solid #e8e6e4;
+  border: 1px solid var(--color-border-subtle);
   border-radius: 8px;
   padding: 1em 1.2em;
-  background: #fff;
+  background: var(--color-bg);
+  color: var(--color-fg-strong);
   display: grid;
   grid-template-columns: 52px 1fr auto;
   gap: 0 1em;
@@ -82,15 +86,15 @@ layout: single
   transition: border-color 0.15s, box-shadow 0.15s;
 }
 .ws-lab-card:hover {
-  border-color: #c8c6c4;
+  border-color: var(--color-border-strong);
   box-shadow: 0 2px 8px rgba(0,0,0,0.06);
 }
 
 .ws-lab-num {
   font-size: 0.72em;
   font-weight: 700;
-  color: #0078d4;
-  background: #deecf9;
+  color: var(--color-pill-blue-fg);
+  background: var(--color-pill-blue-bg);
   border-radius: 6px;
   padding: 0.35em 0;
   text-align: center;
@@ -105,7 +109,7 @@ layout: single
 .ws-lab-title {
   font-size: 0.92em;
   font-weight: 600;
-  color: #323130;
+  color: var(--color-fg-strong);
   margin: 0 0 0.25em;
   line-height: 1.35;
 }
@@ -114,11 +118,11 @@ layout: single
   text-decoration: none;
 }
 .ws-lab-title a:hover {
-  color: #0078d4;
+  color: var(--color-accent);
 }
 .ws-lab-desc {
   font-size: 0.8em;
-  color: #605e5c;
+  color: var(--color-fg-muted);
   line-height: 1.5;
   margin: 0;
   display: -webkit-box;
@@ -143,20 +147,20 @@ layout: single
   white-space: nowrap;
 }
 .ws-pill-duration {
-  background: #f3f2f1;
-  color: #605e5c;
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-muted);
 }
 .ws-pill-level-100 {
-  background: #e6f2e6;
-  color: #0e700e;
+  background: var(--color-pill-green-bg);
+  color: var(--color-pill-green-fg);
 }
 .ws-pill-level-200 {
-  background: #deecf9;
-  color: #004578;
+  background: var(--color-pill-blue-bg);
+  color: var(--color-pill-blue-fg);
 }
 .ws-pill-level-300 {
-  background: #f0e6fc;
-  color: #5b2d8e;
+  background: var(--color-pill-purple-bg);
+  color: var(--color-pill-purple-fg);
 }
 </style>
 
@@ -212,9 +216,9 @@ layout: single
 {% endfor %}
 </ol>
 
-<section id="feedback" style="margin-top: 3em; padding-top: 2em; border-top: 1px solid #e8e6e4;">
-  <h2 style="font-size: 1.1em; font-weight: 700; color: #323130; margin: 0 0 0.5em;">Feedback</h2>
-  <p style="font-size: 0.85em; color: #605e5c; margin: 0 0 1.2em;">Found an issue or have a suggestion? Leave a comment below (requires GitHub sign-in).</p>
+<section id="feedback" style="margin-top: 3em; padding-top: 2em; border-top: 1px solid var(--color-border-subtle);">
+  <h2 style="font-size: 1.1em; font-weight: 700; color: var(--color-fg-strong); margin: 0 0 0.5em;">Feedback</h2>
+  <p style="font-size: 0.85em; color: var(--color-fg-muted); margin: 0 0 1.2em;">Found an issue or have a suggestion? Leave a comment below (requires GitHub sign-in).</p>
   <script src="https://utteranc.es/client.js"
     repo="{{ site.comments.utterances.repo }}"
     issue-term="{{ site.comments.utterances.issue_term }}"

--- a/about/index.md
+++ b/about/index.md
@@ -12,8 +12,11 @@ classes: wide
 .page__meta { display: none; }
 
 .about-hero {
-  background: linear-gradient(135deg, #0f1b2d 0%, #1a3a5c 50%, #0f2440 100%);
-  color: #fff;
+  background: linear-gradient(135deg,
+    var(--color-lab-grad-1) 0%,
+    var(--color-lab-grad-2) 50%,
+    var(--color-lab-grad-3) 100%);
+  color: var(--color-on-lab-header);
   padding: 3em 2.5em;
   border-radius: 10px;
   margin: -0.5em 0 2.5em;
@@ -27,7 +30,7 @@ classes: wide
   right: -20%;
   width: 500px;
   height: 500px;
-  background: radial-gradient(circle, rgba(0,120,212,0.15) 0%, transparent 70%);
+  background: radial-gradient(circle, var(--color-lab-hero-glow) 0%, transparent 70%);
   pointer-events: none;
 }
 .about-hero h2 {
@@ -37,7 +40,7 @@ classes: wide
   letter-spacing: -0.02em;
   border: none;
   padding: 0;
-  color: #fff;
+  color: var(--color-on-lab-header);
 }
 .about-hero p {
   font-size: 1em;
@@ -50,12 +53,12 @@ classes: wide
 .about-section-title {
   font-size: 1em;
   font-weight: 700;
-  color: #323130;
+  color: var(--color-fg-strong);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0 0 1em;
   padding-bottom: 0.5em;
-  border-bottom: 2px solid #e8e6e4;
+  border-bottom: 2px solid var(--color-border-subtle);
 }
 
 .team-grid {
@@ -92,20 +95,20 @@ classes: wide
   transition: box-shadow 0.2s ease;
 }
 .team-card:hover .team-avatar {
-  box-shadow: 0 4px 20px rgba(0,120,212,0.15);
+  box-shadow: 0 4px 20px var(--color-accent-tint-3);
 }
 
 .team-name {
   font-size: 0.82em;
   font-weight: 600;
-  color: #323130;
+  color: var(--color-fg-strong);
   margin: 0;
   letter-spacing: -0.01em;
 }
 
 .team-role {
   font-size: 0.72em;
-  color: #a19f9d;
+  color: var(--color-fg-disabled);
   margin: 0.15em 0 0;
   line-height: 1.3;
 }
@@ -116,7 +119,7 @@ classes: wide
 }
 .about-content p {
   font-size: 0.92em;
-  color: #605e5c;
+  color: var(--color-fg-muted);
   line-height: 1.7;
   margin: 0 0 1em;
 }

--- a/about/index.md
+++ b/about/index.md
@@ -136,7 +136,7 @@ classes: wide
   {% for member in site.data.team %}
   <li class="team-card">
     <a href="https://github.com/{{ member.github }}" target="_blank" rel="noopener">
-      <img class="team-avatar" src="https://github.com/{{ member.github }}.png?size=128" alt="{{ member.name }}">
+      <img class="team-avatar" src="https://github.com/{{ member.github }}.png?size=128" alt="">
       <div class="team-name">{{ member.name }}</div>
     </a>
     {% if member.role != "" %}<div class="team-role">{{ member.role }}</div>{% endif %}

--- a/assets/css/_tokens.scss
+++ b/assets/css/_tokens.scss
@@ -1,0 +1,348 @@
+// ---------------------------------------------------------------------------
+// Design tokens — air-theme color system
+//
+// Every color consumed in main.scss and _includes/webchat/styles.html resolves
+// through a CSS custom property defined here. Four palettes ship:
+//
+//   :root                       → Light (default)
+//   [data-theme="dark"]         → Dark
+//   [data-theme="hc"]           → High contrast (WCAG AAA, forced-colors-safe)
+//   [data-theme] absent         → follows prefers-color-scheme via @mixin
+//   [data-theme="light"]        → explicit opt-out of system dark
+//
+// User selection is written to <html data-theme="…"> by assets/js/a11y-settings.js.
+// A pre-paint script in _includes/head/custom.html sets the attribute before
+// CSS loads to prevent a flash of wrong theme.
+// ---------------------------------------------------------------------------
+
+// --- Light palette (default) -----------------------------------------------
+
+:root {
+  // Surfaces
+  --color-bg:              #ffffff;
+  --color-bg-subtle:       #faf9f8;
+  --color-bg-elevated:     #f3f2f1;
+  --color-bg-input:        #f0efed;
+  --color-bg-input-hover:  #eae9e7;
+
+  // Text — failing grays darkened to pass WCAG AA (≥ 4.5:1 on white)
+  --color-fg:              #201f1e;
+  --color-fg-strong:       #323130;
+  --color-fg-body:         #3b3a39;
+  --color-fg-muted:        #605e5c;
+  --color-fg-subtle:       #6e6c6a;   // was #8a8886 (3.3:1) → 5.0:1
+  --color-fg-disabled:     #757371;   // was #a19f9d (2.8:1) → 4.6:1
+  --color-fg-placeholder:  #767472;   // was #b3b0ad (2.3:1) → 4.5:1
+  --color-fg-hint:         #605e5c;   // was #c8c6c4 (1.8:1) → reuse muted (6.0:1)
+  --color-fg-inverse:      #ffffff;
+
+  // Borders
+  --color-border:          #e1dfdd;
+  --color-border-subtle:   #e8e6e4;
+  --color-border-strong:   #d2d0ce;
+  --color-divider:         #eae8e6;
+
+  // Accent (Microsoft blue)
+  --color-accent:          #0078d4;
+  --color-accent-hover:    #106ebe;
+  --color-accent-active:   #005a9e;
+  --color-accent-deep:     #004578;
+  --color-accent-on:       #ffffff;
+  --color-accent-tint:     rgba(0, 120, 212, 0.08);
+  --color-accent-tint-2:   rgba(0, 120, 212, 0.12);
+  --color-accent-tint-3:   rgba(0, 120, 212, 0.25);
+  --color-accent-tint-4:   rgba(0, 120, 212, 0.30);
+  --color-accent-tint-5:   rgba(0, 120, 212, 0.35);
+
+  // User-message bubble uses deeper ink for readability on the tint background
+  --color-user-bubble-bg:  rgba(0, 120, 212, 0.08);
+  --color-user-bubble-fg:  #1a3a5c;
+
+  // Semantic
+  --color-success:         #0e700e;
+  --color-success-border:  #a7e3a5;
+  --color-danger:          #c4314b;
+  --color-danger-border:   #f1bbbc;
+
+  // Lab-header gradient stops
+  --color-lab-grad-1:      #0f1b2d;
+  --color-lab-grad-2:      #1a3a5c;
+  --color-lab-grad-3:      #0f2440;
+  --color-lab-hero-glow:   rgba(0, 120, 212, 0.12);
+  --color-on-lab-header:   #ffffff;
+  --color-on-lab-header-muted: rgba(255, 255, 255, 0.8);
+  --color-lab-pill-bg:     rgba(255, 255, 255, 0.15);
+  --color-lab-pill-bg-soft:rgba(255, 255, 255, 0.10);
+  --color-lab-pill-border: rgba(255, 255, 255, 0.20);
+  --color-lab-pill-level-100-bg: rgba(16, 124, 16, 0.25);
+  --color-lab-pill-level-100-fg: #a3e4a3;
+  --color-lab-pill-level-200-bg: rgba(0, 120, 212, 0.25);
+  --color-lab-pill-level-200-fg: #9ecbf6;
+  --color-lab-pill-level-300-bg: rgba(127, 57, 251, 0.25);
+  --color-lab-pill-level-300-fg: #c9a8fc;
+
+  // Effects
+  --shadow-panel:          -8px 0 40px rgba(0, 0, 0, 0.08), -1px 0 0 rgba(0, 0, 0, 0.04);
+  --shadow-tag:            -2px 0 12px rgba(0, 0, 0, 0.04);
+  --shadow-tag-hover:      -3px 0 16px rgba(0, 0, 0, 0.08);
+  --shadow-send:           0 2px 6px var(--color-accent-tint-4);
+  --shadow-send-hover:     0 3px 10px var(--color-accent-tint-5);
+  --shadow-send-active:    0 1px 3px var(--color-accent-tint-3);
+  --bubble-bot-bg:         rgba(0, 0, 0, 0.04);
+  --overlay-bg:            rgba(15, 27, 45, 0.06);
+  --scrollbar-thumb:       #d2d0ce;
+
+  // Focus
+  --focus-ring:            0 0 0 2px var(--color-bg), 0 0 0 4px var(--color-accent);
+  --focus-ring-inset:      inset 0 0 0 2px var(--color-accent);
+
+  // Journey / learning-path accents (index page)
+  --color-journey-blue:    #0078d4;
+  --color-journey-green:   #107c10;
+  --color-journey-purple:  #7f39fb;
+  --color-journey-orange:  #ff8c00;
+
+  // Skill-level pills (used on event/workshop cards — light-surface variants)
+  --color-pill-blue-bg:    #deecf9;
+  --color-pill-blue-fg:    #004578;
+  --color-pill-green-bg:   #e6f2e6;
+  --color-pill-green-fg:   #0e700e;
+  --color-pill-purple-bg:  #f0e6fc;
+  --color-pill-purple-fg:  #5b2d8e;
+
+  // Typography scaling (1 = 16px root). Mutated at runtime by a11y-settings.js.
+  --font-scale:            1;
+}
+
+// --- Shared dark palette (used by [data-theme="dark"] and system-pref) -----
+
+@mixin dark-tokens {
+  --color-bg:              #1b1a19;
+  --color-bg-subtle:       #201f1e;
+  --color-bg-elevated:     #2b2a29;
+  --color-bg-input:        #2f2e2d;
+  --color-bg-input-hover:  #3a3938;
+
+  --color-fg:              #f3f2f1;
+  --color-fg-strong:       #ffffff;
+  --color-fg-body:         #e1dfdd;
+  --color-fg-muted:        #c8c6c4;
+  --color-fg-subtle:       #b3b0ad;
+  --color-fg-disabled:     #a19f9d;
+  --color-fg-placeholder:  #a19f9d;
+  --color-fg-hint:         #c8c6c4;
+  --color-fg-inverse:      #1b1a19;
+
+  --color-border:          #3b3a39;
+  --color-border-subtle:   #323130;
+  --color-border-strong:   #484644;
+  --color-divider:         #323130;
+
+  --color-accent:          #4cc2ff;
+  --color-accent-hover:    #69cbff;
+  --color-accent-active:   #2c9ce0;
+  --color-accent-deep:     #1a7dbf;
+  --color-accent-on:       #0a1929;
+  --color-accent-tint:     rgba(76, 194, 255, 0.12);
+  --color-accent-tint-2:   rgba(76, 194, 255, 0.22);
+  --color-accent-tint-3:   rgba(76, 194, 255, 0.30);
+  --color-accent-tint-4:   rgba(76, 194, 255, 0.40);
+  --color-accent-tint-5:   rgba(76, 194, 255, 0.50);
+
+  --color-user-bubble-bg:  rgba(76, 194, 255, 0.18);
+  --color-user-bubble-fg:  #e1f1ff;
+
+  --color-success:         #5cc05c;
+  --color-success-border:  #2d5a2d;
+  --color-danger:          #f07385;
+  --color-danger-border:   #5a2530;
+
+  --color-lab-grad-1:      #0a1220;
+  --color-lab-grad-2:      #122c45;
+  --color-lab-grad-3:      #0a1a2f;
+
+  --bubble-bot-bg:         rgba(255, 255, 255, 0.06);
+  --overlay-bg:            rgba(0, 0, 0, 0.45);
+  --scrollbar-thumb:       #484644;
+
+  --shadow-panel:          -8px 0 40px rgba(0, 0, 0, 0.5), -1px 0 0 rgba(255, 255, 255, 0.04);
+  --shadow-tag:            -2px 0 12px rgba(0, 0, 0, 0.35);
+  --shadow-tag-hover:      -3px 0 16px rgba(0, 0, 0, 0.55);
+
+  --focus-ring:            0 0 0 2px var(--color-bg), 0 0 0 4px var(--color-accent);
+
+  --color-journey-blue:    #4cc2ff;
+  --color-journey-green:   #5cc05c;
+  --color-journey-purple:  #c9a8fc;
+  --color-journey-orange:  #ffb86c;
+
+  --color-pill-blue-bg:    rgba(76, 194, 255, 0.18);
+  --color-pill-blue-fg:    #9ecbf6;
+  --color-pill-green-bg:   rgba(92, 192, 92, 0.18);
+  --color-pill-green-fg:   #a3e4a3;
+  --color-pill-purple-bg:  rgba(201, 168, 252, 0.18);
+  --color-pill-purple-fg:  #c9a8fc;
+
+  color-scheme: dark;
+}
+
+[data-theme="dark"] { @include dark-tokens; }
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) { @include dark-tokens; }
+}
+
+// Ensures an explicit [data-theme="light"] wins over a system dark preference.
+[data-theme="light"] { color-scheme: light; }
+
+// --- High-contrast palette (black / white / yellow) ------------------------
+
+[data-theme="hc"] {
+  --color-bg:              #000000;
+  --color-bg-subtle:       #000000;
+  --color-bg-elevated:     #000000;
+  --color-bg-input:        #000000;
+  --color-bg-input-hover:  #111111;
+
+  --color-fg:              #ffffff;
+  --color-fg-strong:       #ffffff;
+  --color-fg-body:         #ffffff;
+  --color-fg-muted:        #ffffff;
+  --color-fg-subtle:       #ffffff;
+  --color-fg-disabled:     #ffff00;
+  --color-fg-placeholder:  #ffff00;
+  --color-fg-hint:         #ffff00;
+  --color-fg-inverse:      #000000;
+
+  --color-border:          #ffffff;
+  --color-border-subtle:   #ffffff;
+  --color-border-strong:   #ffffff;
+  --color-divider:         #ffffff;
+
+  --color-accent:          #ffff00;
+  --color-accent-hover:    #ffff66;
+  --color-accent-active:   #cccc00;
+  --color-accent-deep:     #999900;
+  --color-accent-on:       #000000;
+  --color-accent-tint:     transparent;
+  --color-accent-tint-2:   #ffff00;
+  --color-accent-tint-3:   #ffff00;
+  --color-accent-tint-4:   #ffff00;
+  --color-accent-tint-5:   #ffff00;
+
+  --color-user-bubble-bg:  #000000;
+  --color-user-bubble-fg:  #ffff00;
+
+  --color-success:         #00ff00;
+  --color-success-border:  #00ff00;
+  --color-danger:          #ff6060;
+  --color-danger-border:   #ff6060;
+
+  --color-lab-grad-1:      #000000;
+  --color-lab-grad-2:      #000000;
+  --color-lab-grad-3:      #000000;
+  --color-lab-hero-glow:   transparent;
+  --color-on-lab-header:   #ffffff;
+  --color-on-lab-header-muted: #ffffff;
+  --color-lab-pill-bg:     #000000;
+  --color-lab-pill-bg-soft:#000000;
+  --color-lab-pill-border: #ffff00;
+  --color-lab-pill-level-100-bg: #000000;
+  --color-lab-pill-level-100-fg: #00ff00;
+  --color-lab-pill-level-200-bg: #000000;
+  --color-lab-pill-level-200-fg: #ffff00;
+  --color-lab-pill-level-300-bg: #000000;
+  --color-lab-pill-level-300-fg: #ffffff;
+
+  --bubble-bot-bg:         #000000;
+  --overlay-bg:            rgba(0, 0, 0, 0.85);
+  --scrollbar-thumb:       #ffffff;
+
+  --shadow-panel:          -8px 0 40px rgba(0, 0, 0, 0.85), -1px 0 0 #ffffff;
+  --shadow-tag:            0 0 0 2px #ffff00;
+  --shadow-tag-hover:      0 0 0 3px #ffff00;
+  --shadow-send:           none;
+  --shadow-send-hover:     none;
+  --shadow-send-active:    none;
+
+  --focus-ring:            0 0 0 3px #000000, 0 0 0 6px #ffff00;
+
+  --color-journey-blue:    #ffff00;
+  --color-journey-green:   #ffff00;
+  --color-journey-purple:  #ffff00;
+  --color-journey-orange:  #ffff00;
+
+  --color-pill-blue-bg:    #000000;
+  --color-pill-blue-fg:    #ffff00;
+  --color-pill-green-bg:   #000000;
+  --color-pill-green-fg:   #00ff00;
+  --color-pill-purple-bg:  #000000;
+  --color-pill-purple-fg:  #ffffff;
+
+  color-scheme: dark;
+  forced-color-adjust: none;
+}
+
+// --- Typography scale -------------------------------------------------------
+// Applied to :root font-size so every em/rem in the site scales proportionally.
+// Default 1 = 16px. a11y-settings.js writes 0.875, 1, or 1.125 via inline style.
+
+:root {
+  font-size: calc(100% * var(--font-scale, 1));
+}
+
+// --- Reduced motion ---------------------------------------------------------
+// Global kill switch for motion-sensitive users. Neutralizes the panel slide,
+// typing-dot pulse, send-button scale, and the new panel-shift transition
+// without removing the elements themselves.
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+// --- Rouge syntax highlighting: dark + HC overrides -------------------------
+// Rouge emits classes via kramdown's rouge highlighter (_config.yml). Default
+// palette is light; override only the tokens we actually encounter in labs.
+
+@mixin rouge-dark {
+  .highlight                  { background: #1f1f1f; color: #e8e8e8; }
+  .highlight .c, .highlight .c1, .highlight .cm, .highlight .cp, .highlight .cs { color: #7c8488; font-style: italic; }     // comments
+  .highlight .k, .highlight .kd, .highlight .kn, .highlight .kp, .highlight .kr, .highlight .kt { color: #ff7ab2; }         // keywords
+  .highlight .s, .highlight .s1, .highlight .s2, .highlight .sb, .highlight .sc, .highlight .sd, .highlight .se, .highlight .sh, .highlight .si, .highlight .sx, .highlight .sr, .highlight .ss { color: #a3e28a; }  // strings
+  .highlight .m, .highlight .mf, .highlight .mh, .highlight .mi, .highlight .mo { color: #ffb86c; }                         // numbers
+  .highlight .nf, .highlight .fm                                    { color: #82aaff; }                                     // functions
+  .highlight .nb, .highlight .bp                                    { color: #82aaff; }                                     // built-ins
+  .highlight .nc, .highlight .nn                                    { color: #c7a5f3; }                                     // classes / namespaces
+  .highlight .nt                                                    { color: #ff7ab2; }                                     // tags
+  .highlight .na                                                    { color: #ffb86c; }                                     // attributes
+  .highlight .o, .highlight .ow                                     { color: #e8e8e8; }                                     // operators
+  .highlight .p                                                     { color: #bdbdbd; }                                     // punctuation
+  .highlight .err                                                   { color: #ff6060; background: transparent; }
+  .highlight .gi                                                    { color: #a3e28a; }                                     // diff +
+  .highlight .gd                                                    { color: #f07385; }                                     // diff -
+  .highlight .gh, .highlight .gu                                    { color: #82aaff; font-weight: 600; }                   // diff header
+}
+
+[data-theme="dark"] { @include rouge-dark; }
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) { @include rouge-dark; }
+}
+
+[data-theme="hc"] .highlight {
+  background: #000000;
+  color: #ffffff;
+  border: 1px solid #ffffff;
+
+  .c, .c1, .cm, .cp, .cs { color: #ffff00; font-style: italic; }
+  .k, .kd, .kn, .kp, .kr, .kt, .nt, .nf, .nc, .nn, .nb, .bp, .fm { color: #ffff00; }
+  .s, .s1, .s2, .sb, .sc, .sd, .se, .sh, .si, .sx, .sr, .ss,
+  .m, .mf, .mh, .mi, .mo, .na, .o, .ow, .p, .gi, .gd, .gh, .gu { color: #ffffff; }
+  .err { color: #ff6060; }
+}

--- a/assets/css/_tokens.scss
+++ b/assets/css/_tokens.scss
@@ -161,7 +161,7 @@
   --color-lab-grad-2:      #122c45;
   --color-lab-grad-3:      #0a1a2f;
 
-  --bubble-bot-bg:         rgba(255, 255, 255, 0.06);
+  --bubble-bot-bg:         rgba(255, 255, 255, 0.08);
   --overlay-bg:            rgba(0, 0, 0, 0.45);
   --scrollbar-thumb:       #484644;
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -223,7 +223,7 @@ aside.sidebar__right {
   box-shadow: none;
 
   .nav__title {
-    font-size: 0.7em;
+    font-size: 0.78em;
     font-weight: 600;
     letter-spacing: 0.05em;
     text-transform: uppercase;
@@ -242,10 +242,10 @@ aside.sidebar__right {
     > li > ul > li > ul { display: none; }
 
     a {
-      font-size: 0.78em;
+      font-size: 0.88em;
       font-weight: 400;
       color: var(--color-fg-muted);
-      padding: 0.3em 0.6em 0.3em 0.8em;
+      padding: 0.35em 0.6em 0.35em 0.8em;
       display: block;
       border-left: 2px solid transparent;
       text-decoration: none;
@@ -266,7 +266,7 @@ aside.sidebar__right {
     // Indent h3 items
     > li > ul > li > a {
       padding-left: 1.4em;
-      font-size: 0.74em;
+      font-size: 0.82em;
       color: var(--color-fg-subtle);
     }
   }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -118,11 +118,14 @@ html, body {
 }
 
 // Page footer
-// --color-accent (#0078d4) on --color-bg-subtle (#faf9f8) computes as 4.31:1
-// under pa11y's sRGB rounding — one notch under AA. Use the darker active
-// accent for footer links to clear 4.5:1 comfortably.
+// Use --color-bg (same as body) so the bottom band paints uniformly even
+// when the Lab Assistant panel shrinks the body width and leaves body's
+// padding-right strip visible beside the footer.
+// --color-accent (#0078d4) on --color-bg (#ffffff) computes as 4.53:1
+// under pa11y's sRGB rounding — clears AA. Under dark/hc the active
+// accent keeps plenty of headroom.
 .page__footer {
-  background: var(--color-bg-subtle);
+  background: var(--color-bg);
   color: var(--color-fg-strong);
   border-top: 1px solid var(--color-border);
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -223,7 +223,7 @@ aside.sidebar__right {
   box-shadow: none;
 
   .nav__title {
-    font-size: 0.78em;
+    font-size: 0.85em;
     font-weight: 600;
     letter-spacing: 0.05em;
     text-transform: uppercase;
@@ -242,10 +242,10 @@ aside.sidebar__right {
     > li > ul > li > ul { display: none; }
 
     a {
-      font-size: 0.88em;
+      font-size: 0.95em;
       font-weight: 400;
       color: var(--color-fg-muted);
-      padding: 0.35em 0.6em 0.35em 0.8em;
+      padding: 0.4em 0.6em 0.4em 0.8em;
       display: block;
       border-left: 2px solid transparent;
       text-decoration: none;
@@ -266,7 +266,7 @@ aside.sidebar__right {
     // Indent h3 items
     > li > ul > li > a {
       padding-left: 1.4em;
-      font-size: 0.82em;
+      font-size: 0.88em;
       color: var(--color-fg-subtle);
     }
   }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -28,8 +28,19 @@ $monospace: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace !default;
 }
 
 // The theme already emits <nav class="skip-links"> with three links. Add
-// tokenized focus styling so they stay readable across all four palettes.
+// tokenized focus styling so they stay readable across all four palettes,
+// and bump the size so Lighthouse's WCAG 2.5.8 target-size audit passes.
+.skip-links {
+  li + li { margin-top: 0.25em; }
+}
 .skip-links a.screen-reader-shortcut {
+  min-height: 24px;
+  min-width: 24px;
+  padding: 0.25em 0.5em;
+  display: inline-flex;
+  align-items: center;
+  line-height: 1.2;
+
   &:focus,
   &:focus-visible {
     background: var(--color-bg);
@@ -38,6 +49,14 @@ $monospace: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace !default;
     outline: none;
     box-shadow: var(--focus-ring);
   }
+}
+
+// Breadcrumb separators via CSS so the <ol> contains only <li> children
+// (axe rule: list must contain only li/script/template).
+.breadcrumbs ol li + li::before {
+  content: "/";
+  padding: 0 0.5em;
+  color: var(--color-fg-muted);
 }
 
 // Give theme switching a smooth, explicit transition on tokenized properties

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -99,13 +99,23 @@ html, body {
 }
 
 // Page footer
+// --color-accent (#0078d4) on --color-bg-subtle (#faf9f8) computes as 4.31:1
+// under pa11y's sRGB rounding — one notch under AA. Use the darker active
+// accent for footer links to clear 4.5:1 comfortably.
 .page__footer {
   background: var(--color-bg-subtle);
-  color: var(--color-fg-muted);
+  color: var(--color-fg-strong);
   border-top: 1px solid var(--color-border);
 
-  a { color: var(--color-accent); }
-  a:hover { color: var(--color-accent-hover); }
+  a { color: var(--color-accent-active); }
+  a:hover { color: var(--color-accent); }
+}
+
+// Theme's footer copyright uses .page__footer-copyright with muted text.
+// Make sure it clears AA contrast on the subtle bg.
+.page__footer-copyright,
+.page__footer .page__footer-follow {
+  color: var(--color-fg-strong);
 }
 
 // Search overlay + results

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -11,7 +11,124 @@ $global-font-family: $sans-serif !default;
 $header-font-family: $sans-serif !default;
 $monospace: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace !default;
 
+@import "tokens";
 @import "minimal-mistakes";
+
+// ---------------------------------------------------------------------------
+// Accessibility utilities
+// ---------------------------------------------------------------------------
+
+// Visually-hidden but screen-reader-reachable (classic sr-only pattern).
+.visually-hidden {
+  position: absolute !important;
+  width: 1px; height: 1px;
+  padding: 0; margin: -1px;
+  overflow: hidden; clip: rect(0, 0, 0, 0);
+  white-space: nowrap; border: 0;
+}
+
+// The theme already emits <nav class="skip-links"> with three links. Add
+// tokenized focus styling so they stay readable across all four palettes.
+.skip-links a.screen-reader-shortcut {
+  &:focus,
+  &:focus-visible {
+    background: var(--color-bg);
+    color: var(--color-accent);
+    border: 2px solid var(--color-accent);
+    outline: none;
+    box-shadow: var(--focus-ring);
+  }
+}
+
+// Give theme switching a smooth, explicit transition on tokenized properties
+// only — avoid `transition: all` to keep paint cost bounded.
+html, body {
+  background-color: var(--color-bg);
+  color: var(--color-fg-strong);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+// ---------------------------------------------------------------------------
+// Theme-owned surfaces (minimal-mistakes air skin)
+//
+// The upstream theme uses hardcoded light colors for the masthead, greedy-nav,
+// page footer, and misc chrome. Re-skin them to our tokens so Dark/HC/System
+// take effect without shadowing each theme partial.
+// ---------------------------------------------------------------------------
+
+.masthead {
+  background: var(--color-bg);
+  border-bottom: 1px solid var(--color-border);
+  box-shadow: none;
+}
+
+.greedy-nav {
+  background: var(--color-bg);
+
+  a { color: var(--color-fg-muted); }
+  a:hover { color: var(--color-fg-strong); }
+
+  .site-title,
+  .site-title:visited { color: var(--color-fg-strong); }
+
+  .site-subtitle { color: var(--color-fg-muted); }
+
+  // Hidden-links dropdown: when masthead is too narrow, minimal-mistakes
+  // spills nav items into a popover here.
+  .hidden-links {
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+
+    a { color: var(--color-fg-muted); }
+    a:hover {
+      background: var(--color-bg-elevated);
+      color: var(--color-fg-strong);
+    }
+  }
+
+  // Greedy-nav own overflow toggle (the triple-bar icon)
+  .greedy-nav__toggle .navicon,
+  .greedy-nav__toggle .navicon::before,
+  .greedy-nav__toggle .navicon::after {
+    background: var(--color-fg-muted);
+  }
+
+  .search__toggle { color: var(--color-fg-muted); }
+  .search__toggle:hover { color: var(--color-fg-strong); }
+}
+
+// Page footer
+.page__footer {
+  background: var(--color-bg-subtle);
+  color: var(--color-fg-muted);
+  border-top: 1px solid var(--color-border);
+
+  a { color: var(--color-accent); }
+  a:hover { color: var(--color-accent-hover); }
+}
+
+// Search overlay + results
+.search-content {
+  background: var(--color-bg);
+  color: var(--color-fg-strong);
+
+  input.search-input {
+    background: var(--color-bg);
+    color: var(--color-fg-strong);
+    border-bottom: 1px solid var(--color-border);
+  }
+}
+.results__found { color: var(--color-fg-muted); }
+.archive__item-title { color: var(--color-fg-strong); }
+.archive__item-excerpt { color: var(--color-fg-muted); }
+
+// Body text fallback (minimal-mistakes sets this on body)
+body { color: var(--color-fg-strong); }
+
+// Generic links in content area
+a { color: var(--color-accent); }
+a:hover, a:focus-visible { color: var(--color-accent-hover); }
 
 // ---------------------------------------------------------------------------
 // Layout: full-width content, no left sidebar gap
@@ -81,7 +198,7 @@ aside.sidebar__right {
     font-weight: 600;
     letter-spacing: 0.05em;
     text-transform: uppercase;
-    color: #a19f9d;
+    color: var(--color-fg-subtle);
     background: transparent;
     padding: 0 0 0.5em;
     margin: 0;
@@ -98,7 +215,7 @@ aside.sidebar__right {
     a {
       font-size: 0.78em;
       font-weight: 400;
-      color: #605e5c;
+      color: var(--color-fg-muted);
       padding: 0.3em 0.6em 0.3em 0.8em;
       display: block;
       border-left: 2px solid transparent;
@@ -106,8 +223,14 @@ aside.sidebar__right {
       transition: color 0.15s, border-color 0.15s;
 
       &:hover {
-        color: #0078d4;
-        border-left-color: #0078d4;
+        color: var(--color-accent);
+        border-left-color: var(--color-accent);
+      }
+
+      &:focus-visible {
+        outline: none;
+        box-shadow: var(--focus-ring-inset);
+        border-radius: 2px;
       }
     }
 
@@ -115,14 +238,14 @@ aside.sidebar__right {
     > li > ul > li > a {
       padding-left: 1.4em;
       font-size: 0.74em;
-      color: #8a8886;
+      color: var(--color-fg-subtle);
     }
   }
 
   li.active > a {
-    color: #0078d4;
+    color: var(--color-accent);
     font-weight: 500;
-    border-left-color: #0078d4;
+    border-left-color: var(--color-accent);
   }
 }
 
@@ -133,7 +256,7 @@ aside.sidebar__right {
   font-size: 1.4em;
   letter-spacing: -0.01em;
   padding-bottom: 0.3em;
-  border-bottom: 1px solid #e1dfdd;
+  border-bottom: 1px solid var(--color-border);
   margin-bottom: 0.5em;
   position: relative;
 
@@ -144,7 +267,7 @@ aside.sidebar__right {
     left: 0;
     width: 50px;
     height: 2px;
-    background: #0078d4;
+    background: var(--color-accent);
   }
 }
 
@@ -156,23 +279,23 @@ table {
   border-spacing: 0;
   border-radius: 6px;
   overflow: hidden;
-  border: 1px solid #e1dfdd;
+  border: 1px solid var(--color-border);
   font-size: 0.88em;
 
   thead th {
-    background: #f3f2f1;
-    color: #323130;
+    background: var(--color-bg-elevated);
+    color: var(--color-fg-strong);
     font-weight: 600;
     font-size: 0.8em;
     letter-spacing: 0.03em;
     text-transform: uppercase;
     padding: 0.7em 1em;
-    border-bottom: 2px solid #e1dfdd;
+    border-bottom: 2px solid var(--color-border);
   }
 
   tbody td {
     padding: 0.65em 1em;
-    border-bottom: 1px solid #f3f2f1;
+    border-bottom: 1px solid var(--color-bg-elevated);
   }
 
   tbody tr:last-child td {
@@ -194,14 +317,14 @@ table {
 // ---------------------------------------------------------------------------
 div.highlighter-rouge, figure.highlight {
   border-radius: 6px;
-  border: 1px solid #e1dfdd;
+  border: 1px solid var(--color-border);
   overflow: hidden;
 }
 
 code { font-family: $monospace; }
 
 p > code, li > code, td > code {
-  background: #f3f2f1;
+  background: var(--color-bg-elevated);
   padding: 0.15em 0.4em;
   border-radius: 4px;
   font-size: 0.85em;
@@ -215,7 +338,7 @@ p > code, li > code, td > code {
     font-size: 1.35em;
     margin-top: 2em;
     padding-bottom: 0.3em;
-    border-bottom: 1px solid #e8e6e4;
+    border-bottom: 1px solid var(--color-border-subtle);
   }
 
   h3 {
@@ -226,7 +349,7 @@ p > code, li > code, td > code {
   h4 {
     font-size: 0.9em;
     margin-top: 1.3em;
-    color: #605e5c;
+    color: var(--color-fg-muted);
   }
 }
 
@@ -235,7 +358,7 @@ p > code, li > code, td > code {
 // ---------------------------------------------------------------------------
 .page__content img {
   border-radius: 6px;
-  border: 1px solid #e1dfdd;
+  border: 1px solid var(--color-border);
 }
 
 // ---------------------------------------------------------------------------
@@ -261,8 +384,11 @@ p > code, li > code, td > code {
 // Lab header (rendered by _layouts/lab.html)
 // ---------------------------------------------------------------------------
 .lab-header {
-  background: linear-gradient(135deg, #0f1b2d 0%, #1a3a5c 50%, #0f2440 100%);
-  color: #fff;
+  background: linear-gradient(135deg,
+    var(--color-lab-grad-1) 0%,
+    var(--color-lab-grad-2) 50%,
+    var(--color-lab-grad-3) 100%);
+  color: var(--color-on-lab-header);
   padding: 2em 2em 1.5em;
   border-radius: 10px;
   margin: -0.5em 0 1.5em;
@@ -276,7 +402,7 @@ p > code, li > code, td > code {
     right: -15%;
     width: 350px;
     height: 350px;
-    background: radial-gradient(circle, rgba(0,120,212,0.12) 0%, transparent 70%);
+    background: radial-gradient(circle, var(--color-lab-hero-glow) 0%, transparent 70%);
     pointer-events: none;
   }
 
@@ -284,7 +410,7 @@ p > code, li > code, td > code {
     font-size: 1.4em;
     font-weight: 700;
     letter-spacing: -0.01em;
-    color: #fff;
+    color: var(--color-on-lab-header);
     margin: 0 0 0.3em;
     line-height: 1.3;
     border: none;
@@ -294,7 +420,7 @@ p > code, li > code, td > code {
 
 .lab-header-desc {
   font-size: 0.9em;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--color-on-lab-header-muted);
   line-height: 1.5;
   margin: 0 0 0.8em;
 }
@@ -323,15 +449,222 @@ p > code, li > code, td > code {
   border-radius: 100px;
   white-space: nowrap;
 }
-.lab-meta-pill-duration { background: rgba(255,255,255,0.15); color: rgba(255,255,255,0.9); }
-.lab-meta-pill-level-100 { background: rgba(16,124,16,0.25); color: #a3e4a3; }
-.lab-meta-pill-level-200 { background: rgba(0,120,212,0.25); color: #9ecbf6; }
-.lab-meta-pill-level-300 { background: rgba(127,57,251,0.25); color: #c9a8fc; }
-.lab-meta-pill-section { background: rgba(255,255,255,0.1); color: rgba(255,255,255,0.8); border: 1px solid rgba(255,255,255,0.2); }
-.lab-meta-pill-feedback { background: rgba(255,255,255,0.1); color: rgba(255,255,255,0.8); border: 1px solid rgba(255,255,255,0.25); text-decoration: none; cursor: pointer; }
-.lab-meta-pill-feedback:hover { background: rgba(255,255,255,0.2); color: #fff; }
+.lab-meta-pill-duration { background: var(--color-lab-pill-bg); color: var(--color-on-lab-header-muted); }
+.lab-meta-pill-level-100 { background: var(--color-lab-pill-level-100-bg); color: var(--color-lab-pill-level-100-fg); }
+.lab-meta-pill-level-200 { background: var(--color-lab-pill-level-200-bg); color: var(--color-lab-pill-level-200-fg); }
+.lab-meta-pill-level-300 { background: var(--color-lab-pill-level-300-bg); color: var(--color-lab-pill-level-300-fg); }
+.lab-meta-pill-section { background: var(--color-lab-pill-bg-soft); color: var(--color-on-lab-header-muted); border: 1px solid var(--color-lab-pill-border); }
+.lab-meta-pill-feedback { background: var(--color-lab-pill-bg-soft); color: var(--color-on-lab-header-muted); border: 1px solid var(--color-lab-pill-border); text-decoration: none; cursor: pointer; }
+.lab-meta-pill-feedback:hover { background: var(--color-lab-pill-bg); color: var(--color-on-lab-header); }
+
+// ---------------------------------------------------------------------------
+// Adaptive Lab Assistant flyout (≥1024 px): shift content instead of overlaying
+// ---------------------------------------------------------------------------
+// Triggered by <html data-panel-open> set in _includes/webchat/script.html.
+// Mobile/tablet keeps the existing overlay behavior (styles.html carries the
+// fixed-position panel CSS; nothing here applies below 1024 px).
+@media (min-width: 1024px) {
+  html[data-panel-open] body {
+    padding-right: 400px;
+    transition: padding-right 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  // Collapse the TOC column while the panel is open — at viewport 1024 px
+  // minus the 400 px panel, the content column would squeeze below ~450 px.
+  // The Lab Assistant doubles as navigation; re-show the TOC on ≥1440 px.
+  html[data-panel-open] .page__content:has(> .sidebar__right) {
+    grid-template-columns: 1fr;
+  }
+  html[data-panel-open] aside.sidebar__right {
+    display: none;
+  }
+}
+
+@media (min-width: 1440px) {
+  // Wide enough to keep both TOC and panel on-screen without crushing content.
+  html[data-panel-open] .page__content:has(> .sidebar__right) {
+    grid-template-columns: 3fr 1fr;
+  }
+  html[data-panel-open] aside.sidebar__right {
+    display: block;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Accessibility settings popover (theme + font size)
+// ---------------------------------------------------------------------------
+.a11y-menu-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  margin-left: auto;
+}
+
+.a11y-menu-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--color-fg-muted);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+
+  &:hover {
+    background: var(--color-bg-elevated);
+    color: var(--color-fg-strong);
+  }
+
+  &[aria-expanded="true"] {
+    background: var(--color-bg-elevated);
+    color: var(--color-accent);
+    border-color: var(--color-border);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+  }
+
+  .a11y-menu-icon { display: block; }
+}
+
+.a11y-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 1000;
+  min-width: 240px;
+  padding: 12px;
+  background: var(--color-bg);
+  color: var(--color-fg-strong);
+  border: 1px solid var(--color-border);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.06);
+
+  &[hidden] { display: none; }
+}
+
+.a11y-menu-section + .a11y-menu-section {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.a11y-menu-label {
+  font-size: 0.72em;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-fg-muted);
+  margin-bottom: 8px;
+}
+
+.a11y-menu-options {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 6px;
+}
+
+.a11y-menu-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg);
+  color: var(--color-fg-strong);
+  font: inherit;
+  font-size: 0.85em;
+  cursor: pointer;
+  text-align: left;
+  transition: background 0.15s ease, border-color 0.15s ease;
+
+  &:hover { background: var(--color-bg-elevated); }
+
+  &[aria-checked="true"] {
+    border-color: var(--color-accent);
+    background: var(--color-accent-tint);
+    color: var(--color-fg);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+  }
+}
+
+.a11y-menu-swatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 1px solid var(--color-border-strong);
+  flex-shrink: 0;
+
+  &--light  { background: #ffffff; }
+  &--dark   { background: #1b1a19; }
+  &--hc     { background: linear-gradient(135deg, #000000 50%, #ffff00 50%); }
+  &--system { background: linear-gradient(135deg, #ffffff 50%, #1b1a19 50%); }
+}
+
+.a11y-menu-textsize {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 6px;
+}
+
+.a11y-menu-textsize-btn {
+  padding: 8px 0;
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  background: var(--color-bg);
+  color: var(--color-fg-strong);
+  font: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+
+  &:hover { background: var(--color-bg-elevated); }
+
+  &[aria-pressed="true"] {
+    border-color: var(--color-accent);
+    background: var(--color-accent-tint);
+    color: var(--color-fg);
+  }
+
+  &:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+  }
+
+  .a11y-ts-sm { font-size: 0.85em; font-weight: 500; }
+  .a11y-ts-md { font-size: 1em;    font-weight: 500; }
+  .a11y-ts-lg { font-size: 1.2em;  font-weight: 600; }
+}
+
+// Masthead layout: push search + settings to the right on wide viewports.
+// Keeps the existing greedy-nav behavior on narrow viewports.
+@media (min-width: 768px) {
+  .greedy-nav .a11y-menu-wrap { margin-left: auto; }
+}
 
 // ---------------------------------------------------------------------------
 // Misc
 // ---------------------------------------------------------------------------
 .page__share { display: none; }
+
+// Global focus outline for any interactive element we haven't styled explicitly.
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+  border-radius: 2px;
+}

--- a/assets/js/a11y-settings.js
+++ b/assets/js/a11y-settings.js
@@ -1,0 +1,169 @@
+(function () {
+  'use strict';
+
+  var STORAGE_KEY = 'mcs-labs.prefs.v1';
+  var SCHEMA_VERSION = 1;
+  var VALID_THEMES = ['light', 'dark', 'hc', 'system'];
+  var VALID_FONT_SCALES = [0.875, 1, 1.125];
+  var DEFAULT_PREFS = { schemaVersion: SCHEMA_VERSION, theme: 'system', fontScale: 1 };
+
+  // --- Storage ---
+
+  function loadPrefs() {
+    try {
+      var raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return Object.assign({}, DEFAULT_PREFS);
+      var p = JSON.parse(raw);
+      if (!p || p.schemaVersion !== SCHEMA_VERSION) return Object.assign({}, DEFAULT_PREFS);
+      if (VALID_THEMES.indexOf(p.theme) < 0) p.theme = DEFAULT_PREFS.theme;
+      if (VALID_FONT_SCALES.indexOf(p.fontScale) < 0) p.fontScale = DEFAULT_PREFS.fontScale;
+      return p;
+    } catch (e) {
+      return Object.assign({}, DEFAULT_PREFS);
+    }
+  }
+
+  function savePrefs(p) {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(p));
+    } catch (e) {
+      // Quota or private-mode failures are non-fatal — the in-memory state
+      // still drives the current page. No user-facing error.
+    }
+  }
+
+  // --- Apply prefs to the document ---
+
+  function applyTheme(theme) {
+    if (theme === 'system') {
+      document.documentElement.removeAttribute('data-theme');
+    } else {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
+  }
+
+  function applyFontScale(scale) {
+    document.documentElement.style.setProperty('--font-scale', String(scale));
+  }
+
+  // --- Menu wiring ---
+
+  function init() {
+    var toggle = document.getElementById('a11yMenuToggle');
+    var menu = document.getElementById('a11yMenu');
+    if (!toggle || !menu) return;
+
+    var prefs = loadPrefs();
+    applyTheme(prefs.theme);
+    applyFontScale(prefs.fontScale);
+
+    var themeButtons = menu.querySelectorAll('[data-theme-value]');
+    var fontButtons = menu.querySelectorAll('[data-font-scale]');
+
+    function syncUI() {
+      themeButtons.forEach(function (btn) {
+        btn.setAttribute('aria-checked',
+          btn.getAttribute('data-theme-value') === prefs.theme ? 'true' : 'false');
+      });
+      fontButtons.forEach(function (btn) {
+        btn.setAttribute('aria-pressed',
+          parseFloat(btn.getAttribute('data-font-scale')) === prefs.fontScale ? 'true' : 'false');
+      });
+    }
+
+    // --- Open/close ---
+
+    function openMenu() {
+      menu.hidden = false;
+      toggle.setAttribute('aria-expanded', 'true');
+      // Focus the currently checked theme for predictable keyboard entry.
+      var checked = menu.querySelector('[aria-checked="true"]') || themeButtons[0];
+      if (checked) checked.focus();
+      document.addEventListener('click', onOutsideClick, true);
+      document.addEventListener('keydown', onEscapeOrNav);
+    }
+
+    function closeMenu(returnFocus) {
+      menu.hidden = true;
+      toggle.setAttribute('aria-expanded', 'false');
+      document.removeEventListener('click', onOutsideClick, true);
+      document.removeEventListener('keydown', onEscapeOrNav);
+      if (returnFocus) toggle.focus();
+    }
+
+    function isOpen() { return !menu.hidden; }
+
+    toggle.addEventListener('click', function () {
+      if (isOpen()) closeMenu(true);
+      else openMenu();
+    });
+
+    function onOutsideClick(e) {
+      if (menu.contains(e.target) || toggle.contains(e.target)) return;
+      closeMenu(false);
+    }
+
+    function onEscapeOrNav(e) {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        closeMenu(true);
+        return;
+      }
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp' ||
+          e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+        var group = document.activeElement && document.activeElement.closest('[role="radiogroup"], .a11y-menu-textsize');
+        if (!group) return;
+        var items = Array.prototype.slice.call(group.querySelectorAll('button'));
+        var idx = items.indexOf(document.activeElement);
+        if (idx < 0) return;
+        e.preventDefault();
+        var next = (e.key === 'ArrowDown' || e.key === 'ArrowRight')
+          ? (idx + 1) % items.length
+          : (idx - 1 + items.length) % items.length;
+        items[next].focus();
+      }
+    }
+
+    // --- Selection handlers ---
+
+    themeButtons.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var value = btn.getAttribute('data-theme-value');
+        if (VALID_THEMES.indexOf(value) < 0) return;
+        prefs.theme = value;
+        applyTheme(value);
+        savePrefs(prefs);
+        syncUI();
+      });
+    });
+
+    fontButtons.forEach(function (btn) {
+      btn.addEventListener('click', function () {
+        var value = parseFloat(btn.getAttribute('data-font-scale'));
+        if (VALID_FONT_SCALES.indexOf(value) < 0) return;
+        prefs.fontScale = value;
+        applyFontScale(value);
+        savePrefs(prefs);
+        syncUI();
+      });
+    });
+
+    // --- Live-track OS theme while in System mode ---
+    // matchMedia fires on OS dark-mode toggle; the CSS @media block repaints
+    // automatically because data-theme is absent — no DOM write needed.
+    if (window.matchMedia) {
+      var mql = window.matchMedia('(prefers-color-scheme: dark)');
+      var onChange = function () { /* no-op: CSS handles repaint */ };
+      if (mql.addEventListener) mql.addEventListener('change', onChange);
+      else if (mql.addListener) mql.addListener(onChange);
+    }
+
+    syncUI();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/bug-bash.html
+++ b/bug-bash.html
@@ -4,7 +4,7 @@ title: Bug Bash Guide
 description: How to report bugs during the MCS Labs Bug Bash event
 ---
 
-<div class="bug-bash-guide">
+<div id="main" role="main" class="bug-bash-guide">
   <div class="bug-bash-header">
     <h1>Bug Bash - MCS Labs</h1>
     <p>Welcome to the MCS Labs Bug Bash! Your goal is to work through the labs and report any issues you find — broken steps, unclear instructions, missing images, incorrect information, or anything else that doesn't work as expected.</p>

--- a/events/index.md
+++ b/events/index.md
@@ -17,12 +17,12 @@ classes: wide
 }
 .ws-index-stats li {
   font-size: 0.88em;
-  color: #605e5c;
+  color: var(--color-fg-muted);
 }
 .ws-index-stats strong {
   font-size: 1.5em;
   display: block;
-  color: #323130;
+  color: var(--color-fg-strong);
   font-weight: 700;
   line-height: 1.2;
 }
@@ -37,23 +37,24 @@ classes: wide
 }
 
 .ws-card {
-  border: 1px solid #e8e6e4;
+  border: 1px solid var(--color-border-subtle);
   border-radius: 8px;
   padding: 1.2em 1.4em;
-  background: #fff;
+  background: var(--color-bg);
+  color: var(--color-fg-strong);
   transition: border-color 0.15s, box-shadow 0.15s;
   display: flex;
   flex-direction: column;
 }
 .ws-card:hover {
-  border-color: #c8c6c4;
+  border-color: var(--color-border-strong);
   box-shadow: 0 2px 8px rgba(0,0,0,0.06);
 }
 
 .ws-card-title {
   font-size: 1em;
   font-weight: 600;
-  color: #323130;
+  color: var(--color-fg-strong);
   margin: 0 0 0.4em;
   line-height: 1.35;
 }
@@ -62,12 +63,12 @@ classes: wide
   text-decoration: none;
 }
 .ws-card-title a:hover {
-  color: #0078d4;
+  color: var(--color-accent);
 }
 
 .ws-card-desc {
   font-size: 0.82em;
-  color: #605e5c;
+  color: var(--color-fg-muted);
   line-height: 1.55;
   margin: 0 0 0.8em;
   flex: 1;
@@ -91,16 +92,16 @@ classes: wide
   white-space: nowrap;
 }
 .ws-idx-pill-labs {
-  background: #deecf9;
-  color: #004578;
+  background: var(--color-pill-blue-bg);
+  color: var(--color-pill-blue-fg);
 }
 .ws-idx-pill-duration {
-  background: #f3f2f1;
-  color: #605e5c;
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-muted);
 }
 .ws-idx-pill-levels {
-  background: #e6f2e6;
-  color: #0e700e;
+  background: var(--color-pill-green-bg);
+  color: var(--color-pill-green-fg);
 }
 </style>
 

--- a/index.md
+++ b/index.md
@@ -16,8 +16,11 @@ header:
 <style>
 /* Hero */
 .home-hero {
-  background: linear-gradient(135deg, #0f1b2d 0%, #1a3a5c 50%, #0f2440 100%);
-  color: #fff;
+  background: linear-gradient(135deg,
+    var(--color-lab-grad-1) 0%,
+    var(--color-lab-grad-2) 50%,
+    var(--color-lab-grad-3) 100%);
+  color: var(--color-on-lab-header);
   padding: 3.5em 2.5em;
   border-radius: 10px;
   margin: -0.5em 0 2.5em;
@@ -31,7 +34,7 @@ header:
   right: -20%;
   width: 500px;
   height: 500px;
-  background: radial-gradient(circle, rgba(0,120,212,0.15) 0%, transparent 70%);
+  background: radial-gradient(circle, var(--color-lab-hero-glow) 0%, transparent 70%);
   pointer-events: none;
 }
 .home-hero h2 {
@@ -41,7 +44,7 @@ header:
   letter-spacing: -0.02em;
   border: none;
   padding: 0;
-  color: #fff;
+  color: var(--color-on-lab-header);
 }
 .home-hero p {
   font-size: 1.05em;
@@ -63,19 +66,19 @@ header:
   transition: all 0.15s;
 }
 .home-hero-actions .btn-primary {
-  background: #0078d4;
-  color: #fff;
+  background: var(--color-accent);
+  color: var(--color-accent-on);
 }
 .home-hero-actions .btn-primary:hover {
-  background: #106ebe;
+  background: var(--color-accent-hover);
 }
 .home-hero-actions .btn-outline {
-  background: rgba(255,255,255,0.1);
-  color: #fff;
-  border: 1px solid rgba(255,255,255,0.3);
+  background: var(--color-lab-pill-bg-soft);
+  color: var(--color-on-lab-header);
+  border: 1px solid var(--color-lab-pill-border);
 }
 .home-hero-actions .btn-outline:hover {
-  background: rgba(255,255,255,0.18);
+  background: var(--color-lab-pill-bg);
   border-color: rgba(255,255,255,0.5);
 }
 .home-stats {
@@ -104,12 +107,12 @@ header:
 .home-section-title {
   font-size: 1em;
   font-weight: 700;
-  color: #323130;
+  color: var(--color-fg-strong);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   margin: 0 0 1em;
   padding-bottom: 0.5em;
-  border-bottom: 2px solid #e8e6e4;
+  border-bottom: 2px solid var(--color-border-subtle);
 }
 
 /* Journey cards */
@@ -122,17 +125,18 @@ header:
   list-style: none;
 }
 .journey-card {
-  border: 1px solid #e8e6e4;
+  border: 1px solid var(--color-border-subtle);
   border-radius: 8px;
   padding: 1.2em 1.3em;
-  background: #fff;
+  background: var(--color-bg);
+  color: var(--color-fg-strong);
   transition: border-color 0.15s, box-shadow 0.15s;
   display: flex;
   flex-direction: column;
   position: relative;
 }
 .journey-card:hover {
-  border-color: #c8c6c4;
+  border-color: var(--color-border-strong);
   box-shadow: 0 2px 8px rgba(0,0,0,0.06);
 }
 .journey-card-accent {
@@ -141,15 +145,15 @@ header:
   border-radius: 2px;
   margin-bottom: 0.8em;
 }
-.accent-blue { background: #0078d4; }
-.accent-green { background: #107c10; }
-.accent-purple { background: #7f39fb; }
-.accent-orange { background: #ff8c00; }
+.accent-blue { background: var(--color-journey-blue); }
+.accent-green { background: var(--color-journey-green); }
+.accent-purple { background: var(--color-journey-purple); }
+.accent-orange { background: var(--color-journey-orange); }
 
 .journey-card h3 {
   font-size: 1em;
   font-weight: 700;
-  color: #323130;
+  color: var(--color-fg-strong);
   margin: 0 0 0.3em;
   border: none;
   padding: 0;
@@ -159,11 +163,11 @@ header:
   text-decoration: none;
 }
 .journey-card h3 a:hover {
-  color: #0078d4;
+  color: var(--color-accent);
 }
 .journey-card-desc {
   font-size: 0.82em;
-  color: #605e5c;
+  color: var(--color-fg-muted);
   line-height: 1.5;
   margin: 0 0 0.8em;
   flex: 1;
@@ -178,8 +182,8 @@ header:
   font-weight: 600;
   padding: 0.2em 0.55em;
   border-radius: 3px;
-  background: #f3f2f1;
-  color: #605e5c;
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-muted);
   white-space: nowrap;
 }
 </style>

--- a/labs/index.md
+++ b/labs/index.md
@@ -17,12 +17,12 @@ classes: wide
 }
 .lab-stats li {
   font-size: 0.88em;
-  color: #605e5c;
+  color: var(--color-fg-muted);
 }
 .lab-stats strong {
   font-size: 1.5em;
   display: block;
-  color: #323130;
+  color: var(--color-fg-strong);
   font-weight: 700;
   line-height: 1.2;
 }
@@ -40,7 +40,7 @@ classes: wide
 .lab-filters-label {
   font-size: 0.78em;
   font-weight: 600;
-  color: #605e5c;
+  color: var(--color-fg-muted);
   text-transform: uppercase;
   letter-spacing: 0.04em;
   margin-right: 0.3em;
@@ -51,36 +51,36 @@ classes: wide
   font-weight: 500;
   padding: 0.35em 0.9em;
   border-radius: 100px;
-  border: 1px solid #e1dfdd;
-  background: #fff;
-  color: #605e5c;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg);
+  color: var(--color-fg-muted);
   cursor: pointer;
   transition: all 0.15s;
   white-space: nowrap;
 }
 .lab-filter-btn:hover {
-  border-color: #c8c6c4;
-  color: #323130;
+  border-color: var(--color-border-strong);
+  color: var(--color-fg-strong);
 }
 .lab-filter-btn.active {
-  background: #323130;
-  border-color: #323130;
-  color: #fff;
+  background: var(--color-fg-strong);
+  border-color: var(--color-fg-strong);
+  color: var(--color-bg);
 }
 .lab-filter-btn.active-100 {
-  background: #0e700e;
-  border-color: #0e700e;
-  color: #fff;
+  background: var(--color-pill-green-fg);
+  border-color: var(--color-pill-green-fg);
+  color: var(--color-bg);
 }
 .lab-filter-btn.active-200 {
-  background: #004578;
-  border-color: #004578;
-  color: #fff;
+  background: var(--color-pill-blue-fg);
+  border-color: var(--color-pill-blue-fg);
+  color: var(--color-bg);
 }
 .lab-filter-btn.active-300 {
-  background: #5b2d8e;
-  border-color: #5b2d8e;
-  color: #fff;
+  background: var(--color-pill-purple-fg);
+  border-color: var(--color-pill-purple-fg);
+  color: var(--color-bg);
 }
 
 .lab-section {
@@ -92,10 +92,10 @@ classes: wide
 .lab-section-header {
   font-size: 1.1em;
   font-weight: 700;
-  color: #323130;
+  color: var(--color-fg-strong);
   margin: 0 0 0.75em;
   padding-bottom: 0.4em;
-  border-bottom: 2px solid #e8e6e4;
+  border-bottom: 2px solid var(--color-border-subtle);
   display: flex;
   align-items: center;
   gap: 0.5em;
@@ -107,12 +107,12 @@ classes: wide
   display: inline-block;
   flex-shrink: 0;
 }
-.section-core .section-dot { background: #0078d4; }
-.section-intermediate .section-dot { background: #107c10; }
+.section-core .section-dot { background: var(--color-journey-blue); }
+.section-intermediate .section-dot { background: var(--color-journey-green); }
 .section-advanced .section-dot { background: #d83b73; }
-.section-specialized .section-dot { background: #7f39fb; }
-.section-optional .section-dot { background: #ff8c00; }
-.section-external .section-dot { background: #605e5c; }
+.section-specialized .section-dot { background: var(--color-journey-purple); }
+.section-optional .section-dot { background: var(--color-journey-orange); }
+.section-external .section-dot { background: var(--color-fg-muted); }
 
 .lab-grid {
   display: grid;
@@ -124,16 +124,17 @@ classes: wide
 }
 
 .lab-card {
-  border: 1px solid #e8e6e4;
+  border: 1px solid var(--color-border-subtle);
   border-radius: 8px;
   padding: 1em 1.2em;
-  background: #fff;
+  background: var(--color-bg);
+  color: var(--color-fg-strong);
   transition: border-color 0.15s, box-shadow 0.15s, opacity 0.2s;
   display: flex;
   flex-direction: column;
 }
 .lab-card:hover {
-  border-color: #c8c6c4;
+  border-color: var(--color-border-strong);
   box-shadow: 0 2px 8px rgba(0,0,0,0.06);
 }
 .lab-card.card-hidden {
@@ -143,7 +144,7 @@ classes: wide
 .lab-card-title {
   font-size: 0.92em;
   font-weight: 600;
-  color: #323130;
+  color: var(--color-fg-strong);
   margin: 0 0 0.4em;
   line-height: 1.35;
 }
@@ -152,12 +153,12 @@ classes: wide
   text-decoration: none;
 }
 .lab-card-title a:hover {
-  color: #0078d4;
+  color: var(--color-accent);
 }
 
 .lab-card-desc {
   font-size: 0.8em;
-  color: #605e5c;
+  color: var(--color-fg-muted);
   line-height: 1.5;
   margin: 0 0 0.7em;
   flex: 1;
@@ -185,27 +186,27 @@ classes: wide
   white-space: nowrap;
 }
 .pill-duration {
-  background: #f3f2f1;
-  color: #605e5c;
+  background: var(--color-bg-elevated);
+  color: var(--color-fg-muted);
 }
 .pill-level-100 {
-  background: #e6f2e6;
-  color: #0e700e;
+  background: var(--color-pill-green-bg);
+  color: var(--color-pill-green-fg);
 }
 .pill-level-200 {
-  background: #deecf9;
-  color: #004578;
+  background: var(--color-pill-blue-bg);
+  color: var(--color-pill-blue-fg);
 }
 .pill-level-300 {
-  background: #f0e6fc;
-  color: #5b2d8e;
+  background: var(--color-pill-purple-bg);
+  color: var(--color-pill-purple-fg);
 }
 
 .lab-empty-msg {
   display: none;
   padding: 2em;
   text-align: center;
-  color: #a19f9d;
+  color: var(--color-fg-disabled);
   font-size: 0.9em;
 }
 .lab-empty-msg.visible {

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -1,0 +1,27 @@
+{
+  "ci": {
+    "collect": {
+      "staticDistDir": "./_site",
+      "url": [
+        "http://localhost/mcs-labs/index.html",
+        "http://localhost/mcs-labs/about/index.html",
+        "http://localhost/mcs-labs/events/index.html",
+        "http://localhost/mcs-labs/bug-bash/index.html",
+        "http://localhost/mcs-labs/labs/mcs-governance/index.html"
+      ],
+      "numberOfRuns": 1,
+      "settings": {
+        "onlyCategories": ["accessibility"],
+        "chromeFlags": "--no-sandbox --disable-setuid-sandbox"
+      }
+    },
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["error", { "minScore": 0.95 }]
+      }
+    },
+    "upload": {
+      "target": "temporary-public-storage"
+    }
+  }
+}

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -3,11 +3,11 @@
     "collect": {
       "staticDistDir": "./_site",
       "url": [
-        "http://localhost/mcs-labs/index.html",
-        "http://localhost/mcs-labs/about/index.html",
-        "http://localhost/mcs-labs/events/index.html",
-        "http://localhost/mcs-labs/bug-bash/index.html",
-        "http://localhost/mcs-labs/labs/mcs-governance/index.html"
+        "http://localhost/index.html",
+        "http://localhost/about/index.html",
+        "http://localhost/events/index.html",
+        "http://localhost/bug-bash.html",
+        "http://localhost/labs/mcs-governance/index.html"
       ],
       "numberOfRuns": 1,
       "settings": {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "mcs-labs-a11y-ci",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Accessibility tooling dev deps for mcs-labs. No runtime code ships from here.",
+  "scripts": {
+    "a11y": "pa11y-ci --config .pa11yci.json",
+    "lighthouse": "lhci autorun"
+  },
+  "devDependencies": {
+    "@lhci/cli": "^0.14.0",
+    "http-server": "^14.1.1",
+    "pa11y-ci": "^3.1.0",
+    "wait-on": "^7.2.0"
+  }
+}


### PR DESCRIPTION
## Summary

Full accessibility + theming pass for `mcs-labs`, plus a batch of Lab Assistant UX polish that surfaced during local testing.

### Themes and accessibility

- **Design tokens** — every site color resolves through CSS custom properties in `assets/css/_tokens.scss`. Four palettes ship: Light (default), Dark, High contrast (WCAG AAA + forced-colors-safe), and System (follows `prefers-color-scheme`).
- **Settings popover in the masthead** — theme switcher + 3-step text size (A− / A / A+). Preferences persist in `localStorage['mcs-labs.prefs.v1']`. A pre-paint inline script applies them before CSS loads so there is no flash of wrong theme.
- **Adaptive Lab Assistant flyout** — at ≥1024 px the panel **shifts** main content via `<body> padding-right`; below 1024 px it stays an overlay. TOC collapses while the panel is open between 1024–1440 px and returns at 1440 px+.
- **Panel stops above the footer** — a new `--wc-panel-bottom` variable tracks how far the footer has scrolled into view, so footer links are never obscured on low-res displays.
- **Panel bg is uniform with the body** — `.page__footer` now uses `--color-bg` so the bottom band paints uniformly when the panel shrinks the body width.
- **Lab Assistant a11y** — pull handle is a native `<button>`; panel upgraded to `role="dialog"` + `aria-labelledby` + `aria-expanded` + `inert` when closed; decorative SVGs get `aria-hidden`; hidden `<label>` for the chat input; proper `:focus-within` ring; secondary grays darkened to pass WCAG 2.1 AA.
- **Breadcrumbs, skip-links, and bug-bash page** fixed for axe `list`, WCAG 2.5.8 target-size, and theme skip-link target.
- **Reduced motion** — global `prefers-reduced-motion` block neutralizes slides, pulses, and panel-shift transitions.
- **Dark Rouge + HC Rouge** syntax highlighting for code blocks.

### Lab Assistant polish (surfaced during testing)

- **Reset conversation button** in the panel header — clears token + watermark + transcript, fetches a fresh token from the endpoint, and re-mounts WebChat on a fresh host element so the new conversation's greeting renders.
- **Theme switch preserves the conversation** — an earlier `MutationObserver` was re-calling `initChat()` on every theme toggle, which spawned a new DirectLine conversation. Removed; chat state now survives theme changes the same way it survives page navigation.
- **Dark-mode chat content** — `styleOptions` (bubble bg/fg, transcript bg, timestamp, suggested-actions) now read from CSS custom properties at render time. A tokenized `adaptiveCardsHostConfig` replaces the SDK's default Light-palette HostConfig so new Adaptive Cards render themed natively. CSS `!important` overrides catch existing `.ac-textRun` / `.ac-richTextBlock` inline colors so labels stay readable, with the required-field asterisk mapped to `--color-danger` to preserve the semantic red.
- **Chat text scales with --font-scale** — bubble text, send input, timestamp, and suggested-action labels bumped to `rem` values that feel visibly different at A-/A/A+ (bubble text was `0.8rem` → `0.95rem`).
- **TOC text larger by default** — `0.78em/0.74em` → `0.95em/0.88em` at the base, closer to body copy.

### CI

- **`.github/workflows/a11y.yml`** runs `pa11y-ci` (WCAG2AA) on every PR. 5/5 URLs pass.
- **`.github/workflows/lighthouse.yml`** runs `@lhci/cli` asserting accessibility ≥ 95. All URLs pass.
- Configs in `.pa11yci.json` and `lighthouserc.json`; dev-deps only in a new root `package.json`.

### Upgrade guardrails

- `minimal-mistakes-jekyll` pinned to `= 4.27.3` so the new `_includes/masthead.html` and `_includes/breadcrumbs.html` shadows don't drift silently on gem bumps.
- `CONTRIBUTING.md` documents the token rule, the theme-bump diff procedure, and the local a11y test commands.

## Phase A — local Docker verification

- [x] Container builds; livereload works
- [x] Home + lab + events + about + bug-bash render without console errors
- [x] Theme cycle Light → Dark → HC → System; preferences persist
- [x] Text size A− / A / A+ scales body text, TOC, and chat bubbles proportionally
- [x] Flyout shift at 1366 × 768: content re-flows, TOC collapses, footer stays accessible
- [x] Below 1024 px panel falls back to overlay; at ≤480 px panel + tag are hidden
- [x] Pre-paint script applies `data-theme` + `--font-scale` before first paint
- [x] Lab Assistant: `role="dialog"`, `aria-expanded` toggles, `inert` when closed, visible focus ring
- [x] Dark-mode Adaptive Cards: label text readable, semantic red `*` preserved, input has visible edges
- [x] Reset button gives a new conversation id + fresh welcome message
- [x] Theme toggle no longer drops the conversation

## Phase B — CI (all green)

- [x] `pa11y-ci`
- [x] `Lighthouse (accessibility)`
- [x] CodeQL (ruby + actions)
- [x] `license/cla`

## Phase C — Production smoke test (after merge)

`build-and-deploy.yml` will publish to https://microsoft.github.io/mcs-labs/ on merge. Post-merge checklist: pa11y-ci + Lighthouse against prod URLs, manual theme/font/flyout/reset smoke, keyboard-only tour. If any regression, a hotfix PR with Phase A + B re-run.