### PR TITLE
Kill the TOC inner scrollbar (the actually-visible one)

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -214,6 +214,19 @@ a:hover, a:focus-visible { color: var(--color-accent-hover); }
     margin: 0 !important;
     padding: 0 !important;
   }
+
+  // Minimal-mistakes' own JS adds a `.sticky` class to aside.sidebar__right
+  // on scroll, which activates the upstream rule:
+  //   .sidebar__right.sticky .toc .toc__menu {
+  //     overflow-y: auto; max-height: calc(100vh - 7em);
+  //   }
+  // That rule is what produces the TOC's internal scrollbar stacked next
+  // to the main viewport scrollbar on long labs. Unset both so the page
+  // scroll handles everything.
+  .sidebar__right.sticky .toc .toc__menu {
+    overflow-y: visible;
+    max-height: none;
+  }
 }
 
 // Mobile: TOC above content in normal flow


### PR DESCRIPTION
## Summary

PR #275 removed \`max-height\` + \`overflow-y: auto\` from \`aside.sidebar__right\` and I verified that on prod. But the inner scrollbar you were still seeing on long labs (e.g. \`agent-builder-m365\` with 14+ top-level headings) is actually on the **`<ul class="toc__menu">` inside** the sidebar — not the sidebar itself.

Minimal-mistakes' theme JS adds a \`.sticky\` class to \`aside.sidebar__right\` as soon as the page scrolls, which activates this upstream rule (from the theme's CSS):

\`\`\`css
.sidebar__right.sticky .toc .toc__menu {
  overflow-y: auto;
  max-height: calc(100vh - 7em);
}
\`\`\`

That's what was still producing the second scrollbar. Overriding it to \`overflow-y: visible; max-height: none\` so the page scroll handles everything.

## Test plan

- [x] \`agent-builder-m365\` (14+ top-level TOC items) — no inner scrollbar, TOC flows below the fold and page scroll reveals the rest
- [x] Short lab (e.g. \`mcs-governance\`) — TOC fits without scrolling, sticky position still pins it

Confirmed the diagnosis via \`getComputedStyle\` on prod:
- \`.toc__menu\` had \`max-height: 681.375px; overflow-y: auto; scrollHeight > clientHeight\` → inner scrollbar visible
- After this CSS override, both properties reset to \`none\` / \`visible\`