### PR TITLE
Chat UI polish + wider main content

### DIFF
--- a/_includes/webchat/panel.html
+++ b/_includes/webchat/panel.html
@@ -42,11 +42,11 @@
       </div>
     </div>
     <div class="wc-panel-header-actions">
-      <button type="button" class="wc-panel-action" id="wcReset" aria-label="Reset conversation" title="Reset conversation">
-        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-          <polyline points="1 4 1 10 7 10"/>
-          <polyline points="23 20 23 14 17 14"/>
-          <path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10M3.51 15a9 9 0 0 0 14.85 3.36L23 14"/>
+      <button type="button" class="wc-panel-action" id="wcReset" aria-label="New conversation" title="New conversation">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <rect x="4" y="4" width="16" height="16" rx="3" ry="3"/>
+          <line x1="12" y1="8" x2="12" y2="16"/>
+          <line x1="8" y1="12" x2="16" y2="12"/>
         </svg>
       </button>
       <button type="button" class="wc-panel-action wc-panel-close" id="wcClose" aria-label="Close Lab Assistant">
@@ -77,7 +77,7 @@
   <div class="wc-sendbox">
     <label for="wcSendInput" class="visually-hidden">Message Lab Assistant</label>
     <div class="wc-sendbox-inner">
-      <input type="text" id="wcSendInput" class="wc-sendbox-input" placeholder="Ask about labs, setup, or workshops..." autocomplete="off" />
+      <textarea id="wcSendInput" class="wc-sendbox-input" placeholder="Ask about labs, setup, or workshops..." rows="2" autocomplete="off"></textarea>
       <button type="button" id="wcSendBtn" class="wc-sendbox-btn" aria-label="Send message">
         <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
           <path d="M5 12h14M12 5l7 7-7 7"/>

--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -282,11 +282,21 @@
       payload: { text: text }
     });
     sendInput.value = '';
+    autoResize();
     sendInput.focus();
   }
 
+  // Textarea auto-resize: grow from the rows=2 baseline up to the CSS
+  // max-height, then scroll internally.
+  function autoResize() {
+    sendInput.style.height = 'auto';
+    sendInput.style.height = Math.min(sendInput.scrollHeight, 160) + 'px';
+  }
+
   sendBtn.addEventListener('click', sendMessage);
+  sendInput.addEventListener('input', autoResize);
   sendInput.addEventListener('keydown', function (e) {
+    // Enter sends; Shift+Enter inserts a newline.
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       sendMessage();

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -82,8 +82,8 @@
   /* --wc-panel-bottom tracks how far the site footer has scrolled into
      view, so the panel never overlaps footer links on low-res displays. */
   bottom: var(--wc-panel-bottom, 0);
-  width: 400px;
-  max-width: 90vw;
+  width: 480px;
+  max-width: 95vw;
   z-index: 99992;
   display: flex;
   flex-direction: column;
@@ -309,12 +309,12 @@ html.wc-restore .wc-tag {
 
 .wc-sendbox-inner {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: 6px;
   background: var(--color-bg-input, #f0efed);
   border: none;
-  border-radius: 24px;
-  padding: 4px 5px 4px 18px;
+  border-radius: 20px;
+  padding: 8px 8px 8px 18px;
   transition: background 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -327,7 +327,8 @@ html.wc-restore .wc-tag {
 }
 
 .wc-sendbox-input,
-.wc-sendbox-input[type="text"] {
+.wc-sendbox-input[type="text"],
+textarea.wc-sendbox-input {
   flex: 1;
   border: none !important;
   border-radius: 0 !important;
@@ -340,10 +341,14 @@ html.wc-restore .wc-tag {
   font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-size: 0.95rem;
   color: var(--color-fg, #201f1e);
-  padding: 9px 0 !important;
+  padding: 4px 0 !important;
   margin: 0 !important;
-  line-height: 1.4;
+  line-height: 1.45;
   min-width: 0;
+  min-height: 44px;
+  max-height: 160px;
+  resize: none !important;
+  overflow-y: auto;
   -webkit-appearance: none;
   appearance: none;
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -165,6 +165,15 @@ a:hover, a:focus-visible { color: var(--color-accent-hover); }
 // ---------------------------------------------------------------------------
 // Layout: full-width content, no left sidebar gap
 // ---------------------------------------------------------------------------
+
+// Widen the main content cap so wide monitors aren't half-empty. The theme
+// defaults to 1280 px which leaves ~320 px of whitespace each side at
+// 1920 wide. 1600 px keeps readable line-length for body copy while giving
+// tables / code blocks / screenshots much more room.
+#main {
+  max-width: 1600px !important;
+}
+
 .page {
   float: none !important;
   width: 100% !important;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -505,12 +505,12 @@ p > code, li > code, td > code {
 // fixed-position panel CSS; nothing here applies below 1024 px).
 @media (min-width: 1024px) {
   html[data-panel-open] body {
-    padding-right: 400px;
+    padding-right: 480px;
     transition: padding-right 0.35s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   // Collapse the TOC column while the panel is open — at viewport 1024 px
-  // minus the 400 px panel, the content column would squeeze below ~450 px.
+  // minus the 480 px panel, the content column would squeeze too narrow.
   // The Lab Assistant doubles as navigation; re-show the TOC on ≥1440 px.
   html[data-panel-open] .page__content:has(> .sidebar__right) {
     grid-template-columns: 1fr;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -174,7 +174,8 @@ a:hover, a:focus-visible { color: var(--color-accent-hover); }
 // bottom band stay aligned with the content column.
 #main,
 .masthead__inner-wrap,
-.page__footer > footer {
+.page__footer > footer,
+nav.breadcrumbs {
   max-width: 1600px !important;
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -170,7 +170,11 @@ a:hover, a:focus-visible { color: var(--color-accent-hover); }
 // defaults to 1280 px which leaves ~320 px of whitespace each side at
 // 1920 wide. 1600 px keeps readable line-length for body copy while giving
 // tables / code blocks / screenshots much more room.
-#main {
+// Masthead inner-wrap and footer also re-cap at 1600 so the top nav and
+// bottom band stay aligned with the content column.
+#main,
+.masthead__inner-wrap,
+.page__footer > footer {
   max-width: 1600px !important;
 }
 


### PR DESCRIPTION
## Summary

Four small UX tweaks.

**1. New conversation button** — the reset-conversation icon in the Lab Assistant header now matches Copilot Studio's test canvas: a rounded square with a `+` in the middle. aria-label / tooltip updated to 'New conversation'.

**2. Wider Lab Assistant panel** — 400 px → **480 px** (max-width 95 vw). The ≥1024 px content-shift `padding-right` on `<body>` tracks the new width so the main column still clears the panel.

**3. Multiline chat input** — `<input type="text">` → `<textarea rows="2">`. Starts at ~52 px (2 lines); auto-grows with content up to 160 px then scrolls internally. `resize: none` so users can't drag. **Enter sends, Shift+Enter inserts a newline** — standard Copilot chat convention. Sendbox-inner aligns children to flex-end so the send button stays at the bottom as the textarea grows.

**4. Wider main content** — `#main { max-width }` bumped from 1280 px → **1600 px**. At 1920-wide monitors this halves the dead whitespace (320 px each side → 160 px each side). Line length on body copy is still comfortable (~100–110 chars on a lab page); tables, code blocks, and screenshots get noticeably more room. At 1366 px laptops the cap is never hit, so nothing changes there.

## Test plan

- [x] Local: textarea 2-line initial, grows to 160 px then scrolls
- [x] Shift+Enter newline; Enter sends
- [x] Panel 480 px wide; at 1366×768 body shifts by 480 px when open
- [x] New-conversation '+' icon visibly a rounded square with a plus
- [x] 1920×1080 content width: `#main` clamps to 1600 px; content area 1568 px
- [ ] pa11y-ci / Lighthouse / CodeQL on CI