### PR TITLE
agenda: fix broken Slides download chips (Git LFS)

### DIFF
--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -358,7 +358,18 @@ layout: single
         {% if item.description %}<p class="ws-agenda-desc">{{ item.description }}</p>{% endif %}
         {% if item.speaker %}<div class="ws-agenda-speaker">— {{ item.speaker }}</div>{% endif %}
         {% if item.slides %}
-          <a class="ws-agenda-slides" href="{{ item.slides | relative_url }}" download>
+          {%- comment -%}
+          Decks live under /presentations/ and are tracked in Git LFS. GitHub Pages
+          serves LFS pointer files (~130 B) rather than resolving them, so we rewrite
+          any in-repo /presentations/ path to the GitHub raw URL which does resolve
+          LFS correctly. External URLs (http/https) pass through unchanged.
+          {%- endcomment -%}
+          {%- assign slides_href = item.slides -%}
+          {%- unless slides_href contains "://" -%}
+            {%- assign slides_path = slides_href | remove_first: "/" -%}
+            {%- assign slides_href = "https://github.com/microsoft/mcs-labs/raw/main/" | append: slides_path -%}
+          {%- endunless -%}
+          <a class="ws-agenda-slides" href="{{ slides_href }}" download>
             <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
             </svg>


### PR DESCRIPTION
## Summary

Follow-up to #278. The Slides chips shipped but linked to `/mcs-labs/presentations/<file>.pptx` — which GitHub Pages serves as a **133-byte LFS pointer file** rather than the real 18 MB deck. Clicking the chip downloaded unreadable pointer text.

## Fix

Rewrite any in-repo `/presentations/` path in a session's `slides:` field to `https://github.com/microsoft/mcs-labs/raw/main/<path>`. The raw URL 302-redirects to `media.githubusercontent.com`, which **does** resolve Git LFS and returns the real `.pptx`.

External `http(s)://` URLs pass through unchanged so future sessions can link to SharePoint / OneDrive / etc.

## Why rewrite in the template vs. update every YAML row

- Rewriting in the Liquid template keeps YAML portable — paths stay repo-relative (`/presentations/…`), they still show up cleanly in diffs, and the `download` attribute still writes a clean filename.
- No batch edit across 20 `slides:` fields; zero chance of drift between bootcamp + MCS-in-a-Day.

## Test plan

- [ ] `/events/bootcamp/` — click any Slides chip → browser downloads the actual `.pptx` (18 MB, not 133 B)
- [ ] `/events/mcs-in-a-day/` — same check on all 5 module rows
- [ ] View-source on the event page — href matches `https://github.com/microsoft/mcs-labs/raw/main/presentations/…`
- [ ] pa11y-ci + Lighthouse a11y green