### PR TITLE
chat(dark): fix unreadable Adaptive Card tiles in Dark/HC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pinned `minimal-mistakes-jekyll` to `= 4.27.3` to protect the new `_includes/masthead.html` shadow from silent upstream drift.
 
 ### Fixed
+- Lab Assistant greeting-card "topic starter" tiles (Product / Pricing / How-To) were unreadable in Dark and High-contrast themes — Adaptive Card SDK baked a near-white inline `background-color` on the tile while the site's `.ac-textBlock` override forced the label to white, producing white text on white. Repaint the tile with `--color-bg-elevated` in Dark / HC / system-dark and invert the bundled monochrome tile icons so they stay visible.
 - Restore lab content overwritten by the redesign merge (PR #265). The `_labs/*.md` collection was frozen at 2026-03-06 and missed subsequent content PRs (#215, #224, #225, #234, #242, #244, #245, #248, #249, #250, #251, #252, #253, #254, #255, #256, #257, #258). Rewrote every lab body from the authoritative `labs/*/README.md` source.
 - Re-apply PR #246 orphan-lab removal: delete `public-website-agent` and `ask-me-anything-30-mins` (lab files and navigation entries) that returned after the redesign merge.
 - Secondary-gray text tokens (TOC titles, timestamps, placeholders, hints) darkened to pass WCAG 2.1 AA contrast; previously several fell between 1.8:1 and 3.3:1.

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -603,6 +603,43 @@ textarea.wc-sendbox-input {
 .wc-panel-body .ac-image { border-radius: 8px; }
 .wc-panel-body .ac-actionSet { margin-top: 8px; display: flex; flex-wrap: wrap; gap: 6px; }
 
+/* Adaptive Card tiles (topic starters, quick-action cards) ship with an
+   inline `background-color` baked into the card JSON — almost always a
+   near-white (#F9F9F9 / #F0F0F0) tone. In dark / HC we repaint those inner
+   containers with theme-correct surface tokens; otherwise our .ac-textBlock
+   rule (which forces --color-fg-strong onto every label) leaves white text
+   on a white tile — the bug seen in the initial greeting card. Inline style
+   attributes set without !important lose to our !important overrides. */
+[data-theme="dark"] .wc-panel-body .ac-container[style*="background-color"] {
+  background-color: var(--color-bg-elevated, #2b2a29) !important;
+}
+[data-theme="hc"] .wc-panel-body .ac-container[style*="background-color"] {
+  background-color: var(--color-bg-elevated, #000) !important;
+  outline: 1px solid var(--color-fg-strong, #fff);
+  outline-offset: -1px;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) .wc-panel-body .ac-container[style*="background-color"],
+  [data-theme="system"] .wc-panel-body .ac-container[style*="background-color"] {
+    background-color: var(--color-bg-elevated, #2b2a29) !important;
+  }
+}
+
+/* Tile icons are typically inline-data SVGs with fill="#212121" (dark on
+   light). When we flip the tile to a dark surface above, those icons become
+   invisible. Flip to pure white via filter. Scoped to ac-images inside a
+   tile so the colorful bot avatar / hero images elsewhere stay untouched. */
+[data-theme="dark"] .wc-panel-body .ac-container[style*="background-color"] img.ac-image,
+[data-theme="hc"] .wc-panel-body .ac-container[style*="background-color"] img.ac-image {
+  filter: brightness(0) invert(1);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) .wc-panel-body .ac-container[style*="background-color"] img.ac-image,
+  [data-theme="system"] .wc-panel-body .ac-container[style*="background-color"] img.ac-image {
+    filter: brightness(0) invert(1);
+  }
+}
+
 /* ===================================
    Responsive
    =================================== */


### PR DESCRIPTION
## Summary

The Lab Assistant greeting card's "topic starter" tiles — Product / Pricing / How-To — were unreadable in Dark and High-contrast themes: white labels on a near-white tile, with icons also invisible.

## Root cause

Two overrides were fighting each other:

1. The Adaptive Cards SDK bakes an inline `background-color: rgb(249, 249, 249)` onto the inner `.ac-container` tile, sourced from the card JSON's `"style": "emphasis"` (or similar). This happens at SDK render time and isn't routed through our `adaptiveCardsHostConfig` tokens.
2. Our site's existing `.ac-textBlock` / `.ac-textRun` rule forces label color to `--color-fg-strong` via `!important` so dark-mode labels on the bot bubble stay readable. In Dark that resolves to `#ffffff`.

Result in Dark: `#ffffff` label on `rgb(249, 249, 249)` tile — ghosted, effectively invisible (contrast ~1.05:1). The tile icons (`.ac-image` inline data-URI SVGs with `fill="#212121"`) went the opposite way: dark gray on a tile that's actually *meant* to be dark, so they disappear once the tile is repainted.

## Fix

1. Repaint the tile's inline background with `--color-bg-elevated` (`#2b2a29` in Dark, `#000` + a `--color-fg-strong` outline in HC) when the active theme is dark, HC, or system-dark. CSS `!important` wins against the SDK's inline style.
2. Invert the bundled monochrome tile icons via `filter: brightness(0) invert(1)`. Scoped to `ac-image` nodes *inside* a themed tile, so the colorful MCS bot avatar and any hero imagery stay untouched.

## Test plan

- [ ] Load the Orlando pass code (`ORLANDO-MCSDAY-Q4Q2`) with `data-theme="dark"` — tile background is `#2b2a29`, labels render in white at ~14:1 contrast, icons render as pure white
- [ ] Same check in `data-theme="hc"` — tile is `#000` with a white outline, icons + labels pure white
- [ ] Light theme unchanged — tile stays `#f9f9f9`, labels and icons stay dark
- [ ] MCS bot avatar (`.ac-image` inside the bot bubble but *not* inside a themed tile) remains full color in every theme
- [ ] pa11y-ci and Lighthouse (accessibility ≥ 95) green