### PR TITLE
presentations: add Module 16 A365 deck content

### DIFF
--- a/presentations/16. A365_CB2.pptx
+++ b/presentations/16. A365_CB2.pptx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ffdd3861204fa0baa1c9efc6a1d46144aae31eb1826f308a10b4073287255fa
+size 262029492


### PR DESCRIPTION
## Summary
- Replaces the 0-byte placeholder at `presentations/16. A365_CB2.pptx` with the real Module 16 (Agent 365) deck (262 MB, tracked via Git LFS per `.gitattributes`).
- No agenda changes required: the only reference in the repo is `_data/agendas/bootcamp.yml:267` → `/presentations/16.%20A365_CB2.pptx`, which already matches the committed filename exactly.

## Scope
- Single-file change. The other in-progress work on this branch (lab3 Teams auth prep) is intentionally **not** included — it will land in a separate PR.

## Test plan
- [ ] Verify `presentations/16. A365_CB2.pptx` opens cleanly in PowerPoint after `git lfs pull`
- [ ] Preview the bootcamp agenda page and click the Module 16 slides link — confirm it downloads the new deck
- [ ] Confirm the deck renders correctly when linked from the agenda (size / load time acceptable)