### PR TITLE
webchat: render quick replies & stop panel resize during scroll

### DIFF
--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -451,7 +451,11 @@
         bubbleFromUserBorderRadius: 14,
         bubbleFromUserTextColor: tok('--color-user-bubble-fg', '#1a3a5c'),
 
-        hideSendBox: true,
+        // Keep the send-box composer mounted so SuggestedActions (quick
+        // replies) render — they live inside <BasicSendBox>, not the
+        // transcript. We hide just the inner input row via CSS instead so
+        // our custom send box (.wc-sendbox) owns the visible input.
+        hideSendBox: false,
         hideUploadButton: true,
 
         suggestedActionBackgroundColor: tok('--color-bg', '#ffffff'),

--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -122,12 +122,11 @@
     persistState();
   }
 
-  // --- Masthead + footer offsets: keep panel inside the "chrome sandwich" ---
-  // The panel is position: fixed and would normally occupy the full right
-  // column between the top and bottom edges of the viewport. We nudge its
-  // top below the masthead (so nav stays reachable) and its bottom above
-  // the visible portion of the site footer (so the footer links are never
-  // obscured).
+  // --- Masthead offset: keep panel below the (non-sticky) masthead ---
+  // The panel is position: fixed. We nudge its top below the masthead so the
+  // top nav stays reachable while the chat is open. The bottom edge stays
+  // pinned to the viewport bottom (panel overlaps the footer when scrolled),
+  // which avoids resizing the chat surface during page scroll.
 
   var chromeOffsetFrame = null;
 
@@ -136,17 +135,6 @@
     var masthead = document.querySelector('.masthead');
     var topPx = masthead ? Math.max(0, Math.ceil(masthead.getBoundingClientRect().bottom)) : 0;
     document.documentElement.style.setProperty('--wc-panel-top', topPx + 'px');
-
-    var footer = document.querySelector('.page__footer') || document.getElementById('footer');
-    var bottomPx = 0;
-    if (footer) {
-      var rect = footer.getBoundingClientRect();
-      var vh = window.innerHeight || document.documentElement.clientHeight;
-      // Footer intrudes into the viewport by (vh - rect.top); clamp so the
-      // panel only shrinks when the footer is actually visible.
-      bottomPx = Math.max(0, Math.ceil(vh - rect.top));
-    }
-    document.documentElement.style.setProperty('--wc-panel-bottom', bottomPx + 'px');
   }
 
   function scheduleChromeOffsets() {

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -79,9 +79,9 @@
   position: fixed;
   top: var(--wc-panel-top, 0);
   right: 0;
-  /* --wc-panel-bottom tracks how far the site footer has scrolled into
-     view, so the panel never overlaps footer links on low-res displays. */
-  bottom: var(--wc-panel-bottom, 0);
+  /* Pin to viewport bottom so the panel never resizes during page scroll —
+     it overlaps the footer when the user scrolls down. */
+  bottom: 0;
   width: 480px;
   max-width: 95vw;
   z-index: 99992;

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -473,8 +473,23 @@ textarea.wc-sendbox-input {
   display: none !important;
 }
 
-/* Hide default send box — we use our own */
+/* SendBox: keep the container mounted so SuggestedActions (quick replies)
+   render inside it, but strip its chrome so it looks invisible above our
+   custom .wc-sendbox. Web Chat's own input row is hidden below. */
 .wc-panel-body .webchat__send-box {
+  background: transparent !important;
+  border: none !important;
+  padding: 0 !important;
+  margin: 0 !important;
+  min-height: 0 !important;
+}
+
+/* Hide Web Chat's actual input form (textarea + buttons). Suggested actions
+   render in a sibling div, so they survive. Selecting `form` inside the send
+   box is robust across Web Chat 4.x versions where the form classname has
+   shifted (.webchat__send-box__main vs .webchat__send-box-text-box). */
+.wc-panel-body .webchat__send-box form,
+.wc-panel-body .webchat__send-box-text-box {
   display: none !important;
 }
 


### PR DESCRIPTION
Two independent Lab Assistant fixes, one commit each.

## 1. Quick replies (suggested actions) don't render

**Symptom:** Bot quick replies like \"Get user\" never appear in the panel.

**Root cause:** In Bot Framework Web Chat 4.x, ` + "`SuggestedActions`" + ` is a child of ` + "`<BasicSendBox>`" + `, **not** the transcript. The Lab Assistant set ` + "`hideSendBox: true`" + ` plus a CSS rule ` + "`.webchat__send-box { display: none !important }`" + ` to make room for a custom send box — and silently took the entire suggested-actions UI down with it. The existing ` + "`suggestedAction*`" + ` style options and ` + "`.webchat__suggested-action__button`" + ` CSS overrides were never reached.

**Fix:** ` + "`hideSendBox: false`" + `, then strip the visible chrome (background/border/padding/min-height) off the send-box container and hide just its inner ` + "`form`" + `. The container survives to host suggested actions, while the custom ` + "`.wc-sendbox`" + ` keeps owning the visible input row.

## 2. Panel resizes during page scroll

**Symptom:** As the user scrolls the page, the chat panel shrinks/grows in real time, jumbling the transcript inside.

**Root cause:** ` + "`applyChromeOffsets()`" + ` was wired to the ` + "`scroll`" + ` listener and recomputed ` + "`--wc-panel-bottom`" + ` to track the visible portion of the site footer. CSS used that variable for the panel's ` + "`bottom`" + `, so every scroll frame altered the panel's height.

**Fix:** Pin the panel ` + "`bottom: 0`" + `; drop the footer-tracking branch in ` + "`applyChromeOffsets()`" + `. The panel now overlaps the footer when scrolled down (standard Intercom/Drift-style chat-panel UX). Masthead-aware top offset is preserved per #271.

## Verification

- [ ] Open any lab page in the devcontainer dev server
- [ ] **Bug 2:** Scroll the page up/down — panel should stay full height (top of viewport content area to bottom of viewport), no shrinking when the footer enters view
- [ ] **Bug 1:** Trigger a bot turn that emits suggested actions (e.g. ask the agent something whose response includes quick replies like \"Get user\") — chips should render between the transcript and the custom send box, with the existing pill styling

> **Note from the author:** I made these changes from a Windows host without Ruby/Jekyll installed, so I could not preview locally. Please verify in the devcontainer before merging — the CSS approach for keeping ` + "`<BasicSendBox>`" + ` mounted-but-invisible is structurally sound but worth eyeballing for any leftover gap above the custom send box when no quick replies are present.