### PR TITLE
webchat: hotfix — switch CDN to jsdelivr (cdn.botframework.com unreachable)

### DIFF
--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -1,4 +1,4 @@
-<script src="https://cdn.botframework.com/botframework-webchat/4.18.0/webchat.js" defer></script>
+<script src="https://cdn.jsdelivr.net/npm/botframework-webchat@4.18.0/dist/webchat.js" defer></script>
 <script>
 (function () {
   'use strict';


### PR DESCRIPTION
## Symptom (production)
Lab Assistant chat hangs at **Connecting…** forever on https://microsoft.github.io/mcs-labs/. Browser console shows:

```
Failed to load resource: net::ERR_NAME_NOT_RESOLVED
@ https://cdn.botframework.com/botframework-webchat/4.18.0/webchat.js
```

## Root cause
` + "`cdn.botframework.com`" + ` (Microsoft's Bot Framework CDN, fronted by ` + "`*.b01.azurefd.net`" + ` Azure Front Door) is intermittently failing DNS resolution from corporate networks. ` + "`nslookup`" + ` shows a timeout on the first attempt and a slow resolve on the second — likely a Front Door / Cisco-Umbrella interaction that's been flaky in the last few hours.

` + "`waitForWebChat()`" + ` (` + "`script.html:308-315`" + `) polls ` + "`window.WebChat`" + ` indefinitely with no timeout. When the script never loads, ` + "`window.WebChat`" + ` is never defined, the promise never resolves, and the status stays at the placeholder ` + "`'Connecting...'`" + ` forever — there's no error UI to surface the underlying load failure.

## Fix
Switch the script ` + "`src`" + ` to ` + "`cdn.jsdelivr.net/npm/botframework-webchat@4.18.0/dist/webchat.js`" + `. Same npm package, same version (4.18.0), no API change. jsdelivr is the CDN the site already uses for FontAwesome — known-resolving from this network — and it returns a 200 with aggressive cache headers (1 year, immutable).

## Not caused by recent PRs
This regression is independent of #291 (which I authored earlier today) — that PR touched only ` + "`hideSendBox`" + `, send-box CSS, and panel layout, never the CDN URL. The fact that the chat appeared to break right after #291 merged is coincidental: the CDN flap and the deploy-triggered hard-refresh of the page collided in time.

## Follow-up worth filing (not in this PR)
` + "`waitForWebChat()`" + ` should add a timeout (e.g. 15 s) and surface ` + "`'Could not load chat'`" + ` so the next time a CDN goes sideways, users get an actionable error instead of an infinite spinner. Happy to do that as a separate PR if helpful.

## Test plan
- [ ] Wait for Build and Deploy to publish
- [ ] Open https://microsoft.github.io/mcs-labs/ in a fresh tab (hard-refresh if cached)
- [ ] Open the Lab Assistant — status should progress ` + "`Connecting...`" + ` → ` + "`Online`" + ` within a couple seconds
- [ ] Send a message; verify a bot response renders normally