### PR TITLE
Revert #292: restore cdn.botframework.com (false alarm — local DNS issue)

### DIFF
--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -1,4 +1,4 @@
-<script src="https://cdn.jsdelivr.net/npm/botframework-webchat@4.18.0/dist/webchat.js" defer></script>
+<script src="https://cdn.botframework.com/botframework-webchat/4.18.0/webchat.js" defer></script>
 <script>
 (function () {
   'use strict';


### PR DESCRIPTION
Reverts #292.

## Why revert
PR #292 swapped the Web Chat library CDN from `cdn.botframework.com` (Microsoft's official Bot Framework CDN, fronted by Azure Front Door) to `cdn.jsdelivr.net`. At the time, `cdn.botframework.com` was failing DNS resolution from the author's network, and we hypothesized a Microsoft Front Door incident.

Confirmed today on a different network: **`cdn.botframework.com` resolves and serves `webchat.js` normally**. The DNS failure was specific to the author's local network — likely a router-level Cisco Umbrella / OpenDNS Family Shield resolver intermittently failing on `*.botframework.com`. The same network also failed to resolve `directline.botframework.com`, which would have broken the chat regardless of the CDN swap (the conversation traffic still goes through `*.botframework.com`).

## What this restores
- `_includes/webchat/script.html:1` script src returns to `https://cdn.botframework.com/botframework-webchat/4.18.0/webchat.js` — the canonical, Microsoft-supported source for Web Chat 4.18.0.

## Out of scope (separate concern)
The duplicate-send-box visual regression introduced by #291 (Web Chat's own input pill leaking through above the custom send box) is *not* fixed by this revert. That has its own pending CSS-only fix waiting on author confirmation; it's independent of which CDN serves the script.

## Test plan
- [ ] Wait for Build and Deploy to publish (~30s)
- [ ] Hard-refresh https://microsoft.github.io/mcs-labs/ on a working network
- [ ] Open the Lab Assistant — status should go `Connecting…` → `Online`