### PR TITLE
Revert #291: webchat fixes (white-bar regression in send-box hide)

### DIFF
--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -122,11 +122,12 @@
     persistState();
   }
 
-  // --- Masthead offset: keep panel below the (non-sticky) masthead ---
-  // The panel is position: fixed. We nudge its top below the masthead so the
-  // top nav stays reachable while the chat is open. The bottom edge stays
-  // pinned to the viewport bottom (panel overlaps the footer when scrolled),
-  // which avoids resizing the chat surface during page scroll.
+  // --- Masthead + footer offsets: keep panel inside the "chrome sandwich" ---
+  // The panel is position: fixed and would normally occupy the full right
+  // column between the top and bottom edges of the viewport. We nudge its
+  // top below the masthead (so nav stays reachable) and its bottom above
+  // the visible portion of the site footer (so the footer links are never
+  // obscured).
 
   var chromeOffsetFrame = null;
 
@@ -135,6 +136,17 @@
     var masthead = document.querySelector('.masthead');
     var topPx = masthead ? Math.max(0, Math.ceil(masthead.getBoundingClientRect().bottom)) : 0;
     document.documentElement.style.setProperty('--wc-panel-top', topPx + 'px');
+
+    var footer = document.querySelector('.page__footer') || document.getElementById('footer');
+    var bottomPx = 0;
+    if (footer) {
+      var rect = footer.getBoundingClientRect();
+      var vh = window.innerHeight || document.documentElement.clientHeight;
+      // Footer intrudes into the viewport by (vh - rect.top); clamp so the
+      // panel only shrinks when the footer is actually visible.
+      bottomPx = Math.max(0, Math.ceil(vh - rect.top));
+    }
+    document.documentElement.style.setProperty('--wc-panel-bottom', bottomPx + 'px');
   }
 
   function scheduleChromeOffsets() {
@@ -451,11 +463,7 @@
         bubbleFromUserBorderRadius: 14,
         bubbleFromUserTextColor: tok('--color-user-bubble-fg', '#1a3a5c'),
 
-        // Keep the send-box composer mounted so SuggestedActions (quick
-        // replies) render — they live inside <BasicSendBox>, not the
-        // transcript. We hide just the inner input row via CSS instead so
-        // our custom send box (.wc-sendbox) owns the visible input.
-        hideSendBox: false,
+        hideSendBox: true,
         hideUploadButton: true,
 
         suggestedActionBackgroundColor: tok('--color-bg', '#ffffff'),

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -79,9 +79,9 @@
   position: fixed;
   top: var(--wc-panel-top, 0);
   right: 0;
-  /* Pin to viewport bottom so the panel never resizes during page scroll —
-     it overlaps the footer when the user scrolls down. */
-  bottom: 0;
+  /* --wc-panel-bottom tracks how far the site footer has scrolled into
+     view, so the panel never overlaps footer links on low-res displays. */
+  bottom: var(--wc-panel-bottom, 0);
   width: 480px;
   max-width: 95vw;
   z-index: 99992;
@@ -473,23 +473,8 @@ textarea.wc-sendbox-input {
   display: none !important;
 }
 
-/* SendBox: keep the container mounted so SuggestedActions (quick replies)
-   render inside it, but strip its chrome so it looks invisible above our
-   custom .wc-sendbox. Web Chat's own input row is hidden below. */
+/* Hide default send box — we use our own */
 .wc-panel-body .webchat__send-box {
-  background: transparent !important;
-  border: none !important;
-  padding: 0 !important;
-  margin: 0 !important;
-  min-height: 0 !important;
-}
-
-/* Hide Web Chat's actual input form (textarea + buttons). Suggested actions
-   render in a sibling div, so they survive. Selecting `form` inside the send
-   box is robust across Web Chat 4.x versions where the form classname has
-   shifted (.webchat__send-box__main vs .webchat__send-box-text-box). */
-.wc-panel-body .webchat__send-box form,
-.wc-panel-body .webchat__send-box-text-box {
   display: none !important;
 }
 


### PR DESCRIPTION
Reverts #291.

## Why
PR #291 attempted two fixes in one commit:

1. **Render quick replies (suggested actions)** — switched `hideSendBox: true → false` and replaced the blanket `.webchat__send-box { display: none }` with a narrower CSS hide of just the inner form. The selector didn't catch every leaking element — the standalone send button (a sibling of the form, also inside `.webchat__send-box__main`) and `.webchat__connectivityStatus` continued to render. Result: a duplicate visible "send a message" pill leaks above the custom dark send box in production.
2. **Stop panel resize during page scroll** — removed footer-tracking from `applyChromeOffsets()` and pinned the panel `bottom: 0`. This part worked correctly.

Author confirmed the white-bar regression in the live site after reverting #292 (CDN swap, also unrelated). Cleanest path back to known-good chat UX is a full revert of #291.

## What this changes back
- `_includes/webchat/script.html` — restores `hideSendBox: true`, restores the masthead+footer chrome-offset logic.
- `_includes/webchat/styles.html` — restores `bottom: var(--wc-panel-bottom, 0)` and the blanket `.webchat__send-box { display: none !important }`.

## Side-effect: panel scroll resize bug returns
The "panel resizes while scrolling the page" bug that #291's second commit fixed *also* comes back with this revert (both fixes were squashed into one commit, so a clean revert undoes both). Author accepted this trade-off — happy to re-implement that fix in a separate, clean, narrow PR after this revert lands.

## Quick replies
Still don't render (back to original behavior). Re-implementation will need to extract `<SuggestedActions>` from Web Chat's `<BasicSendBox>` host using a different approach (custom React component reading from the activity stream, or finer-grained CSS that doesn't rely on the send-box composer being mounted).

## Test plan
- [ ] Wait for Build and Deploy
- [ ] Hard-refresh https://microsoft.github.io/mcs-labs/ on a working network
- [ ] Open the Lab Assistant — confirm:
  - Single dark custom send box at the bottom (no white pill above it)
  - No "Connecting…" dots indicator visible inside the panel body (panel-header status is the only one)
  - Status flips `Connecting…` → `Online` and chat is usable