### PR TITLE
webchat: render quick replies + stop panel resize on scroll

### DIFF
--- a/_includes/webchat/panel.html
+++ b/_includes/webchat/panel.html
@@ -73,6 +73,13 @@
     </div>
   </div>
 
+  <!-- Quick replies (suggested actions). Rendered by script.html when an
+       incoming bot activity carries activity.suggestedActions.actions. We
+       build our own buttons here instead of letting Web Chat render its
+       built-in <SuggestedActions> inside <BasicSendBox>, because hiding
+       that subtree was the source of the duplicate-send-box bug. -->
+  <div class="wc-quickreplies" id="wcQuickReplies" role="group" aria-label="Quick replies" hidden></div>
+
   <!-- Custom send box -->
   <div class="wc-sendbox">
     <label for="wcSendInput" class="visually-hidden">Message Lab Assistant</label>

--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -24,6 +24,7 @@
   var status = document.getElementById('wcStatus');
   var sendInput = document.getElementById('wcSendInput');
   var sendBtn = document.getElementById('wcSendBtn');
+  var quickRepliesEl = document.getElementById('wcQuickReplies');
 
   var isOpen = false;
   var chatInitializing = false;
@@ -122,12 +123,11 @@
     persistState();
   }
 
-  // --- Masthead + footer offsets: keep panel inside the "chrome sandwich" ---
-  // The panel is position: fixed and would normally occupy the full right
-  // column between the top and bottom edges of the viewport. We nudge its
-  // top below the masthead (so nav stays reachable) and its bottom above
-  // the visible portion of the site footer (so the footer links are never
-  // obscured).
+  // --- Masthead offset: keep panel below the (non-sticky) masthead ---
+  // The panel is position: fixed. We nudge its top below the masthead so the
+  // top nav stays reachable while the chat is open. The bottom edge stays
+  // pinned to the viewport bottom (panel overlaps the footer when scrolled),
+  // which avoids resizing the chat surface during page scroll.
 
   var chromeOffsetFrame = null;
 
@@ -136,17 +136,6 @@
     var masthead = document.querySelector('.masthead');
     var topPx = masthead ? Math.max(0, Math.ceil(masthead.getBoundingClientRect().bottom)) : 0;
     document.documentElement.style.setProperty('--wc-panel-top', topPx + 'px');
-
-    var footer = document.querySelector('.page__footer') || document.getElementById('footer');
-    var bottomPx = 0;
-    if (footer) {
-      var rect = footer.getBoundingClientRect();
-      var vh = window.innerHeight || document.documentElement.clientHeight;
-      // Footer intrudes into the viewport by (vh - rect.top); clamp so the
-      // panel only shrinks when the footer is actually visible.
-      bottomPx = Math.max(0, Math.ceil(vh - rect.top));
-    }
-    document.documentElement.style.setProperty('--wc-panel-bottom', bottomPx + 'px');
   }
 
   function scheduleChromeOffsets() {
@@ -157,6 +146,65 @@
   // Back-compat aliases for earlier variable names used elsewhere in this file.
   var applyMastheadOffset = applyChromeOffsets;
   var scheduleMastheadOffset = scheduleChromeOffsets;
+
+  // --- Quick replies (suggested actions) ---
+  // We render our own buttons from activity.suggestedActions instead of
+  // showing Web Chat's built-in <SuggestedActions>, so we don't need
+  // hideSendBox: false (which leaks the input form + connectivity dots).
+
+  function clearQuickReplies() {
+    if (!quickRepliesEl) return;
+    while (quickRepliesEl.firstChild) quickRepliesEl.removeChild(quickRepliesEl.firstChild);
+    quickRepliesEl.hidden = true;
+  }
+
+  function renderQuickReplies(actions) {
+    if (!quickRepliesEl) return;
+    clearQuickReplies();
+    if (!actions || !actions.length) return;
+    actions.forEach(function (action) {
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'wc-quickreply';
+      btn.textContent = action.title || action.displayText || action.text || action.value || '';
+      btn.addEventListener('click', function () {
+        var t = action.type || 'imBack';
+        if (t === 'openUrl' && action.value) {
+          // Open in a new tab; keep the buttons available so the user can
+          // pick a different one if they came back without picking.
+          window.open(action.value, '_blank', 'noopener,noreferrer');
+          return;
+        }
+        // Pre-clear so a slow round-trip can't double-fire on a second click.
+        clearQuickReplies();
+        if (!chatStore || !chatReady) return;
+        if (t === 'postBack') {
+          chatStore.dispatch({
+            type: 'WEB_CHAT/SEND_POST_BACK',
+            payload: { value: action.value }
+          });
+        } else if (t === 'messageBack') {
+          chatStore.dispatch({
+            type: 'WEB_CHAT/SEND_MESSAGE_BACK',
+            payload: {
+              value: action.value,
+              text: action.text || action.title,
+              displayText: action.displayText || action.title
+            }
+          });
+        } else {
+          // imBack and any default: send as a regular text message so the
+          // bot sees it like a typed user reply.
+          chatStore.dispatch({
+            type: 'WEB_CHAT/SEND_MESSAGE',
+            payload: { text: action.value || action.title }
+          });
+        }
+      });
+      quickRepliesEl.appendChild(btn);
+    });
+    quickRepliesEl.hidden = false;
+  }
 
   // --- Sendbox disabled state ---
 
@@ -250,6 +298,7 @@
     chatReady = false;
     chatInitializing = false;
     fallingBack = false;
+    clearQuickReplies();
 
     // Replace the host element entirely so renderWebChat mounts a fresh
     // React tree. Just clearing innerHTML leaves React's _reactRootContainer
@@ -277,6 +326,8 @@
   function sendMessage() {
     var text = sendInput.value.trim();
     if (!text || !chatStore || !chatReady) return;
+    // Typing a new message supersedes any pending quick replies.
+    clearQuickReplies();
     chatStore.dispatch({
       type: 'WEB_CHAT/SEND_MESSAGE',
       payload: { text: text }
@@ -418,6 +469,17 @@
                   showTyping();
                 } else {
                   hideTyping();
+                }
+                // Quick replies: render our own buttons from
+                // activity.suggestedActions. A bot message without
+                // suggestedActions clears any stale ones from a prior turn.
+                if (activity.type === 'message') {
+                  var sa = activity.suggestedActions;
+                  if (sa && Array.isArray(sa.actions) && sa.actions.length) {
+                    renderQuickReplies(sa.actions);
+                  } else {
+                    clearQuickReplies();
+                  }
                 }
               }
               if (activity.type !== 'typing' && activity.id &&

--- a/_includes/webchat/styles.html
+++ b/_includes/webchat/styles.html
@@ -79,9 +79,9 @@
   position: fixed;
   top: var(--wc-panel-top, 0);
   right: 0;
-  /* --wc-panel-bottom tracks how far the site footer has scrolled into
-     view, so the panel never overlaps footer links on low-res displays. */
-  bottom: var(--wc-panel-bottom, 0);
+  /* Pin to viewport bottom so the panel never resizes during page scroll —
+     it overlaps the footer when the user scrolls down. */
+  bottom: 0;
   width: 480px;
   max-width: 95vw;
   z-index: 99992;
@@ -294,6 +294,47 @@ html.wc-restore .wc-tag {
     transform: scale(1.3);
     opacity: 1;
   }
+}
+
+/* ===========================================
+   Quick Replies (suggested actions)
+   Rendered by script.html from activity.suggestedActions, instead of
+   relying on Web Chat's built-in <SuggestedActions> inside <BasicSendBox>.
+   =========================================== */
+.wc-quickreplies {
+  flex-shrink: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 8px 18px 4px;
+  background: var(--color-bg-subtle, #faf9f8);
+}
+
+.wc-quickreplies[hidden] {
+  display: none !important;
+}
+
+.wc-quickreply {
+  background: var(--color-bg, #fff);
+  border: 1px solid var(--color-accent, #0078d4);
+  color: var(--color-accent, #0078d4);
+  border-radius: 100px;
+  font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  font-size: 0.85rem;
+  font-weight: 500;
+  padding: 6px 14px;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+
+.wc-quickreply:hover {
+  background: var(--color-accent, #0078d4);
+  color: var(--color-accent-on, #fff);
+}
+
+.wc-quickreply:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring, 0 0 0 2px #fff, 0 0 0 4px #0078d4);
 }
 
 /* ===========================================


### PR DESCRIPTION
Two independent fixes, verified end-to-end in the local dev container against the live Copilot Studio agent (workshop pass code submitted, real bot turn).

## 1. Quick replies (suggested actions) now render

**Symptom:** Bot quick replies like *Get a User Account*, *What is the implementation guide?* never appear in the panel.

**Root cause:** Bot Framework Web Chat renders ` + "`<SuggestedActions>`" + ` inside ` + "`<BasicSendBox>`" + `, not the transcript. Hiding the send box (` + "`hideSendBox: true`" + ` + ` + "`.webchat__send-box { display: none }`" + `) takes the suggested-actions UI down with it.

**Fix — Approach A (custom UI, not DOM hiding):** A previous attempt (#291, reverted via #294) tried selectively hiding parts of ` + "`<BasicSendBox>`" + ` to keep just the suggested actions visible. The CSS selectors didn't catch the standalone send button or the connectivity-status pill, so a duplicate visible send box leaked into production.

This PR takes a different approach — build our own quick-reply UI from the activity stream so we don't depend on Web Chat's internal DOM at all:

- New ` + "`<div id=\"wcQuickReplies\">`" + ` in ` + "`panel.html`" + `, between the typing indicator and the custom send box.
- Existing ` + "`DIRECT_LINE/INCOMING_ACTIVITY`" + ` middleware extended: if a bot message carries ` + "`activity.suggestedActions.actions`" + `, render our own ` + "`<button class=\"wc-quickreply\">`" + `s; if a follow-up bot message arrives without them, clear stale ones.
- Click dispatches through ` + "`chatStore`" + `:
  - ` + "`imBack`" + ` / default text → ` + "`WEB_CHAT/SEND_MESSAGE`" + `
  - ` + "`postBack`" + ` → ` + "`WEB_CHAT/SEND_POST_BACK`" + `
  - ` + "`messageBack`" + ` → ` + "`WEB_CHAT/SEND_MESSAGE_BACK`" + `
  - ` + "`openUrl`" + ` → ` + "`window.open(value, '_blank', 'noopener,noreferrer')`" + `
- Pre-clear on click so a slow round-trip can't double-fire on a second click. Also clear on user typing into the custom send box, and on conversation reset.

` + "`hideSendBox: true`" + ` is preserved → no Web Chat send-box DOM is mounted → zero risk of the duplicate-send-box regression returning.

## 2. Panel no longer resizes during page scroll

**Symptom:** As the user scrolls the page, the chat panel shrinks/grows in real time, jumbling the transcript inside.

**Root cause:** ` + "`applyChromeOffsets()`" + ` was wired to the ` + "`scroll`" + ` listener and recomputed ` + "`--wc-panel-bottom`" + ` to track the visible portion of the site footer. CSS used that variable for the panel's ` + "`bottom`" + `, so every scroll frame altered the panel's height.

**Fix:** Pin the panel ` + "`bottom: 0`" + `; drop the footer-tracking branch in ` + "`applyChromeOffsets()`" + `. The panel now overlaps the footer when scrolled (standard Intercom/Drift-style chat UX). Masthead-aware top offset preserved per #271 — top nav stays reachable.

This is the same fix that was in #291 alongside the broken quick-replies attempt; reverted en bloc by #294. Re-applied here in a known-good context.

## Verification (local dev container)

Spun up the repo's ` + "`.devcontainer/devcontainer.json`" + ` Ruby image with the worktree bind-mounted, ran ` + "`bundle exec jekyll serve --force_polling`" + `, drove the live Copilot Studio agent through Playwright:

| Test | Result |
|---|---|
| Chat connects on local | ✅ status ` + "`Online`" + ` |
| Pass code (` + "`MCA-VRT-R0T8`" + `) submitted via Adaptive Card | ✅ accepted, bot replied |
| Quick replies render | ✅ 5 chips: *Get a User Account*, *What is the implementation guide?*, *Send a support email*, *Request additional environment(s)*, *Set office location* |
| Click on a chip dispatches as ` + "`imBack`" + ` | ✅ chips cleared, bot received message and replied with consent card |
| Single dark send box (no white pill leak) | ✅ confirmed via screenshot |
| Panel height across scroll positions | ✅ ` + "`panel.bottom == window.innerHeight`" + ` at top/middle/bottom; height variance across scrolls = **0 px** |
| At bottom-of-page scroll, panel correctly overlaps footer | ✅ footer ` + "`top=648 bottom=763`" + `, panel still extends to ` + "`bottom=763`" + ` |

## Files changed
- ` + "`_includes/webchat/panel.html`" + ` (+7) — new ` + "`<div id=\"wcQuickReplies\">`" + `
- ` + "`_includes/webchat/script.html`" + ` (~80 changes) — quick-replies wiring + ` + "`applyChromeOffsets`" + ` simplification
- ` + "`_includes/webchat/styles.html`" + ` (+44) — ` + "`.wc-quickreplies`" + ` & ` + "`.wc-quickreply`" + ` styles + ` + "`bottom: 0`" + ` change

## Test plan (post-deploy on prod)
- [ ] Open the Lab Assistant on https://microsoft.github.io/mcs-labs/, submit a workshop pass code
- [ ] Confirm the 5 quick reply pills render between the transcript and send box
- [ ] Click a chip — verify bot processes it and chips clear
- [ ] Scroll the page up/down; verify panel height stays constant and overlaps the footer at the bottom of the page