### PR TITLE
webchat: harden quick-reply rendering (XSS, replay, focus trap)

### DIFF
--- a/_includes/webchat/script.html
+++ b/_includes/webchat/script.html
@@ -170,6 +170,8 @@
       btn.addEventListener('click', function () {
         var t = action.type || 'imBack';
         if (t === 'openUrl' && action.value) {
+          // Only allow http(s) URLs — block javascript: and other schemes.
+          if (!/^https?:\/\//i.test(action.value)) return;
           // Open in a new tab; keep the buttons available so the user can
           // pick a different one if they came back without picking.
           window.open(action.value, '_blank', 'noopener,noreferrer');
@@ -221,9 +223,9 @@
   // --- Focus trap ---
 
   function getFocusableElements() {
-    return panel.querySelectorAll(
+    return Array.from(panel.querySelectorAll(
       'button:not([disabled]), input:not([disabled]), [tabindex]:not([tabindex="-1"])'
-    );
+    )).filter(function (el) { return el.offsetParent !== null; });
   }
 
   function handleFocusTrap(e) {
@@ -473,7 +475,8 @@
                 // Quick replies: render our own buttons from
                 // activity.suggestedActions. A bot message without
                 // suggestedActions clears any stale ones from a prior turn.
-                if (activity.type === 'message') {
+                if (activity.type === 'message' &&
+                    !(replayedActivityIds && replayedActivityIds.has(activity.id))) {
                   var sa = activity.suggestedActions;
                   if (sa && Array.isArray(sa.actions) && sa.actions.length) {
                     renderQuickReplies(sa.actions);


### PR DESCRIPTION
## Summary

Three fixes for the quick-reply UI introduced in #295:

- **XSS guard on `openUrl` actions** — `window.open(action.value)` now rejects non-`http(s)` schemes, preventing `javascript:` URI injection from a malicious or compromised bot activity
- **Skip suggested actions during session replay** — `renderQuickReplies` is now gated on `replayedActivityIds` so stale quick-reply buttons from a prior session don't render on page reload
- **Focus trap excludes hidden elements** — `getFocusableElements()` filters by `el.offsetParent !== null` so buttons inside the hidden `#wcQuickReplies` container don't skew the Tab cycling boundary

## Test plan

- [ ] Open webchat, trigger a bot response with suggested actions → buttons render and work
- [ ] Reload page → stale quick-reply buttons should NOT appear
- [ ] With quick replies hidden, Tab/Shift+Tab should cycle correctly through visible panel elements
- [ ] Verify no `javascript:` or `data:` URIs can open via openUrl actions

@Dewain27 — flagged these during a review of #295, would appreciate your eyes on the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)