### PR TITLE
Improve h4 section heading visibility in lab content

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -526,9 +526,12 @@ p > code, li > code, td > code {
   }
 
   h4 {
-    font-size: 0.9em;
-    margin-top: 1.3em;
-    color: var(--color-fg-muted);
+    font-size: 1.05em;
+    font-weight: 600;
+    color: var(--color-fg-strong);
+    margin-top: 1.8em;
+    padding-bottom: 0.2em;
+    border-bottom: 2px solid var(--color-accent);
   }
 }
 


### PR DESCRIPTION
## Summary

Section headings (`h4`) in lab content were nearly invisible across all themes (light, dark, HC) because they were styled *smaller* than body text and in muted gray. The visual hierarchy was inverted — h4s read as de-emphasized body copy rather than as headings.

## What changed

Single CSS block in `assets/css/main.scss`, scoped to `.page__content h4`:

- `font-size: 0.9em` → `1.05em` (now larger than body)
- Added `font-weight: 600`
- `color: var(--color-fg-muted)` → `var(--color-fg-strong)` (full contrast in every theme)
- Added 2px accent-colored `border-bottom` mirroring h2's section-divider pattern
- Increased `margin-top` from 1.3em → 1.8em for better section breathing room

h2 retains its 1px neutral underline, so h2 > h4 hierarchy stays chromatically distinct (different color, different weight).

## Scope

- Affects only `.page__content h4` — site nav, hero, footer, and other layouts are unchanged
- No JS, no markup changes, no token changes — pure CSS

## Test plan

- [ ] Visual check on `/labs/agent-builder-m365/` (21 h4s — good repetition test)
- [ ] Verify in light, dark, and high-contrast themes
- [ ] Confirm h4s in long page TOCs and lab indexes still look correct
- [ ] Spot-check a few other labs for regressions (e.g., `/labs/copilot-studio-kit/`, `/labs/mcs-orchestration/`)