### PR TITLE
Component Collections lab: update visible duration to 45 minutes

### DIFF
--- a/_labs/component-collections.md
+++ b/_labs/component-collections.md
@@ -24,7 +24,7 @@ Learn how to create, share, and manage reusable component collections to package
 
 | Level | Persona | Duration | Purpose |
 | ----- | ------- | -------- | ------- |
-| 300 | Maker | 30 minutes | After completing this lab, you will be able to create component collections that package topics and knowledge into reusable bundles, share component collections across multiple agents, manage collection ownership with primary agent settings, and understand how component collections integrate with Power Platform solutions. |
+| 300 | Maker | 45 minutes | After completing this lab, you will be able to create component collections that package topics and knowledge into reusable bundles, share component collections across multiple agents, manage collection ownership with primary agent settings, and understand how component collections integrate with Power Platform solutions. |
 
 ---
 
@@ -58,7 +58,7 @@ Think of component collections like shared libraries in software development:
 - "I need to control which agents can use a shared component to prevent unauthorized reuse"
 - "I want to package and distribute standard components across my organization"
 
-**In 30 minutes, you'll learn how to create, share, and manage component collections - giving you a powerful tool for building scalable, maintainable agent architectures.**
+**In 45 minutes, you'll learn how to create, share, and manage component collections - giving you a powerful tool for building scalable, maintainable agent architectures.**
 
 ---
 

--- a/labs/component-collections/README.md
+++ b/labs/component-collections/README.md
@@ -8,7 +8,7 @@ Learn how to create, share, and manage reusable component collections to package
 
 | Level | Persona | Duration | Purpose |
 | ----- | ------- | -------- | ------- |
-| 300 | Maker | 30 minutes | After completing this lab, you will be able to create component collections that package topics and knowledge into reusable bundles, share component collections across multiple agents, manage collection ownership with primary agent settings, and understand how component collections integrate with Power Platform solutions. |
+| 300 | Maker | 45 minutes | After completing this lab, you will be able to create component collections that package topics and knowledge into reusable bundles, share component collections across multiple agents, manage collection ownership with primary agent settings, and understand how component collections integrate with Power Platform solutions. |
 
 ---
 
@@ -42,7 +42,7 @@ Think of component collections like shared libraries in software development:
 - "I need to control which agents can use a shared component to prevent unauthorized reuse"
 - "I want to package and distribute standard components across my organization"
 
-**In 30 minutes, you'll learn how to create, share, and manage component collections - giving you a powerful tool for building scalable, maintainable agent architectures.**
+**In 45 minutes, you'll learn how to create, share, and manage component collections - giving you a powerful tool for building scalable, maintainable agent architectures.**
 
 ---
 


### PR DESCRIPTION
## Summary
The Component Collections lab's frontmatter declares `duration: 45` (matching the bootcamp agenda), but the visible Lab Details table and intro paragraph still said `30 minutes`. This PR aligns the visible copy with both the metadata and the agenda.

## Changes
- `_labs/component-collections.md` (Jekyll-rendered page)
  - Line 27: Lab Details table — `30 minutes` → `45 minutes`
  - Line 61: intro paragraph — `In 30 minutes, you'll learn...` → `In 45 minutes, you'll learn...`
- `labs/component-collections/README.md` (GitHub-readable mirror)
  - Line 11 and line 45: same edits

## Test plan
- [ ] Render `/labs/component-collections/` locally and confirm the Lab Details row shows `45 minutes`
- [ ] Confirm the rendered bootcamp agenda continues to show Lab 6 (Component Collections) at 45 min
- [ ] Verify the GitHub README at `labs/component-collections/README.md` displays the updated values