### PR TITLE
Fix Lab Assistant tag overlapping content on event agenda pages

### DIFF
--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -73,10 +73,13 @@ layout: single
   margin: 0 0 1em;
 }
 
-/* Timeline */
+/* Timeline.
+   Right padding clears the docked Lab Assistant tag (position: fixed; right: 0;
+   ~40-50px wide). Event pages lack a TOC sidebar, so without this the duration
+   pills on the right edge of each row sit underneath the tag. */
 .ws-agenda {
   list-style: none;
-  padding: 0;
+  padding: 0 60px 0 0;
   margin: 0 0 2em;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Problem
On event/agenda pages (`/events/bootcamp`, `/events/mcs-in-a-day`, etc.), the docked Lab Assistant tag covered the right-edge content of agenda rows — most notably the duration pills (e.g., `45 min`, `60 min`). Other layouts (lab pages) don't hit this because their TOC sidebar already pushes content left; event pages have no TOC since the agenda *is* the navigation.

## Fix
Added 60 px of right padding to `.ws-agenda` in `_layouts/event.html`. The tag is roughly 40-50 px wide (12 px horizontal padding × 2 + 18 px icon + 1 px border), so 60 px clears it with ~10-17 px of breathing room.

When the panel opens, `body` already gets `padding-right: 480px` (`assets/css/main.scss:649`), so the nested 60 px on `.ws-agenda` is harmless and just sits inside the larger gutter.

## Scope
Targeted only `.ws-agenda`. The hero banner (`.ws-hero`) has a 540 px max-width on its description and small ws-stats list, so its content didn't visibly clip under the tag in testing — left untouched to keep the diff minimal.

## Test plan
- [ ] On `/events/bootcamp` with the Lab Assistant docked (closed), the right-side duration pills sit clearly to the left of the tag
- [ ] Day header underlines stop short of the tag area, not running underneath it
- [ ] Open the Lab Assistant panel — agenda content still readable with no double-padding visual artifacts
- [ ] Repeat on `/events/mcs-in-a-day` and other event pages
- [ ] Mobile width (~375 px viewport): 60 px right padding still leaves usable agenda width