### PR TITLE
Tracker refresh via auto-merging PR (fix branch-protection block)

### DIFF
--- a/.github/workflows/tracker-data.yml
+++ b/.github/workflows/tracker-data.yml
@@ -71,6 +71,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          base: main
           branch: bot/tracker-data-refresh
           delete-branch: true
           commit-message: "chore(tracker): refresh issues snapshot"

--- a/.github/workflows/tracker-data.yml
+++ b/.github/workflows/tracker-data.yml
@@ -11,6 +11,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   refresh:
@@ -59,11 +60,34 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit and push
+      # Open (or update) a PR with the snapshot change. We can't push direct to main
+      # because the repo's "Changes must be made through a pull request" rule blocks
+      # the GITHUB_TOKEN. peter-evans/create-pull-request reuses the same branch name
+      # across runs, so subsequent refreshes update the existing PR instead of opening
+      # new ones.
+      - name: Open refresh PR
         if: steps.diff.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add assets/data/issues.json
-          git commit -m "chore(tracker): refresh issues snapshot [skip ci]"
-          git push
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: bot/tracker-data-refresh
+          delete-branch: true
+          commit-message: "chore(tracker): refresh issues snapshot"
+          title: "chore(tracker): refresh issues snapshot"
+          body: |
+            Automated refresh of `assets/data/issues.json` by the `tracker-data` workflow.
+
+            - Source: GitHub Issues GraphQL API
+            - Cadence: every 15 min via cron, plus issue/PR events
+            - Idempotency: this PR only opens when the snapshot content changes (the workflow diffs against the previous committed snapshot, ignoring `generatedAt`).
+
+            Safe to merge whenever — the change is data-only.
+          labels: |
+            type: infrastructure
+
+      - name: Enable auto-merge on the refresh PR
+        if: steps.cpr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-number }}" --repo "$GITHUB_REPOSITORY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Labels: `type: bootcamp-feature`, `status: triage`, `status: backlog`, `status: in-progress`.** Support the Backlog Tracker's Triage → Backlog → In Progress → Done lifecycle.
 
 ### Changed
+- **Backlog Tracker refresh workflow now opens an auto-merging PR instead of pushing direct to `main`.** The repo's branch protection ("Changes must be made through a pull request") was rejecting the bot's direct push, so every 15-min cron run was failing at the commit step. Switched `.github/workflows/tracker-data.yml` to use `peter-evans/create-pull-request@v7` on a stable bot branch (`bot/tracker-data-refresh`) plus `gh pr merge --squash --auto` so each snapshot change opens (or updates) a PR that lands automatically when CI clears. The architecture (snapshot in repo at `assets/data/issues.json`, page reads it as a static asset) is unchanged.
 - **Issue template rename: "Redesign feedback" → "Portal Enhancements".** The air-theme redesign is now just "the site," so the template covering site-wide bugs/suggestions has been renamed and broadened. File renamed `.github/ISSUE_TEMPLATE/redesign-feedback.yml` → `portal_enhancement.yml`; label `redesign` → `portal-enhancement`. The "Which page?" dropdown now includes `Backlog tracker (/tracker/)`.
 - **Label rename: `feedback` → `discussion`.** Distinguishes open-ended threads from the existing `question` label (which implies a specific answer is wanted).
 


### PR DESCRIPTION
## Summary

Follow-up to #315. After merge, the `tracker-data` workflow's 15-min cron started failing at the commit/push step because `microsoft/mcs-labs`'s `main` branch is protected — direct pushes by `github-actions[bot]` are rejected with `GH013: Changes must be made through a pull request`. So the page is serving a frozen seed snapshot and would stay frozen until manual intervention.

## Fix

Switch the workflow to **open an auto-merging PR** instead of pushing directly:

- `peter-evans/create-pull-request@v7` on a stable branch `bot/tracker-data-refresh` — reused across runs, so only ever zero or one refresh PR is open.
- `gh pr merge --squash --auto` enables auto-merge, so the PR lands as soon as CI clears.
- `delete-branch: true` cleans the bot branch up after merge; the next refresh run recreates it.

Page architecture (snapshot in repo → page loads static JSON) is unchanged. This is a publication-mechanism fix only.

## Test plan

- [x] **Phase A — Local Docker.** Not applicable — workflow only runs in CI.
- [x] **Phase B — PR CI.** `build-and-deploy.yml`, `lighthouse.yml`, `pa11y-ci`, CodeQL pass. The `tracker-data.yml` workflow on this PR will be triggered by the PR open + by the next cron tick — confirm it produces a `bot/tracker-data-refresh` PR (or finds the data unchanged and exits clean).
- [ ] **Phase C — Post-merge production.** Wait for the next 15-min cron after merge. Expected: one auto-merging PR opens on `bot/tracker-data-refresh`, lands within a few minutes, and Pages rebuilds. Page at `microsoft.github.io/mcs-labs/tracker/` shows updated `Updated N min ago` timestamp.