### PR TITLE
mcs-orchestration: fix audit findings from #327

### DIFF
--- a/_data/lab-config.yml
+++ b/_data/lab-config.yml
@@ -125,6 +125,12 @@ lab_metadata:
     id: mcs-alm
     section: intermediate
     title: Application Lifecycle Management (ALM) in Copilot Studio
+  290:
+    difficulty: Advanced
+    duration: 60
+    id: mcs-orchestration
+    section: intermediate
+    title: Orchestration with Copilot Studio
   300:
     difficulty: Advanced
     duration: 30
@@ -225,6 +231,7 @@ lab_journeys:
   mcs-governance: [business-user, developer]
   mcs-mcp-external: [developer]
   mcs-multi-agent: [business-user, developer]
+  mcs-orchestration: [developer]
   mcs-tools: [business-user, developer]
   measure-success: [developer]
   pipelines-and-source-control: [developer]
@@ -259,6 +266,7 @@ legacy_lab_orders:
   mcs-governance: 195
   mcs-mcp-external: 600
   mcs-multi-agent: 250
+  mcs-orchestration: 290
   mcs-tools: 270
   measure-success: 400
   pipelines-and-source-control: 410
@@ -378,6 +386,7 @@ lab_orders:
       - 260
       - 270
       - 280
+      - 290
     optional: [500]
     specialized: [400, 410, 420, 430, 440, 450]
 

--- a/_labs/mcs-orchestration.md
+++ b/_labs/mcs-orchestration.md
@@ -95,11 +95,10 @@ You'll start by ensuring a sample connected agent is configured and working in y
 ## Prerequisites
 
 - Access to Microsoft Copilot Studio
-- Dataverse search enabled in environment
-- Access to Dataverse unbound action connector
-- Sample data loaded into Dataverse tables
-- Access to Account / Contact table in environment
-- Access to modify views and create search indexes on Account / Contact table
+- A Power Platform environment where you can edit Dataverse table views and toggle environment settings (System Administrator or System Customizer)
+- Sample data loaded into the Account and Contact Dataverse tables (the (sample) records used throughout Use Cases #1 and #2)
+- The pre-loaded **Account Data Lookup Agent** available in your environment (Use Case #1 verifies and publishes it)
+- For Use Case #3 only: an environment where Enhanced Task Completion (preview), Dataverse Intelligence (Work IQ), and Dataverse MCP servers can be turned on
 
 ---
 
@@ -192,7 +191,7 @@ Confirm the environment is ready and the sample connected agent is published.
 1. Select **Quick Find Active Accounts** option from the list of Views
 
 1. Select **View Column** to verify the following list of columns are in the view, you may have to scroll to see all of the included columns:
-   - Address1: State or Providence
+   - Address 1: State/Province
    - Address1: Postal Code
    - Address1: City
    - Annual Revenue
@@ -203,7 +202,7 @@ Confirm the environment is ready and the sample connected agent is published.
     ![Account View](images/image-20.png)
 
 1. Add the ability to search on certain fields by making sure that the following items are in the **Find by** on the bottom right. Select the **Edit find table columns** option to check:
-   - Address1: State or Providence
+   - Address 1: State/Province
    - Address1: Postal Code
    - Address1: City
 
@@ -243,7 +242,7 @@ Confirm the environment is ready and the sample connected agent is published.
     > [!IMPORTANT]
     > DO NOT navigate away until the save and publish is completed!
 
-#### Test and Publish the Account and Contact Information Agent
+#### Test and Publish the Account Data Lookup Agent
 
 1. In the Copilot Studio tab in your browser, go to the **Account Data Lookup Agent**
 
@@ -395,7 +394,7 @@ Open the **Account Data Lookup Agent** in Copilot Studio and walk through each o
    - **Input descriptions tell the planner what value belongs in the input *and how to format it*.** The planner uses this text to translate a user's words into the exact value the tool expects to receive. Vague input descriptions are the most common reason a tool gets called with the wrong argument — even when the right tool was picked.
    - Read the description on the `search` input carefully:
 
-     > *"Search query that includes state in the format of two digit state code in all caps, 5 digit zip code, city, the account name, and/or the account name"*
+     > *"Search query that includes state in the format of two digit state code in all caps, 5 digit zip code, city, the account name, and/or the primary contact name"*
 
      Notice how strict the **state code formatting requirement** is: *"two digit state code in all caps"*. That single phrase tells the planner to translate the user's word *"Texas"* into `TX`, not `texas`, not `Texas`, not `Tex`. Dataverse search only matches if the value comes in correctly cased and formatted — so this description is what makes the difference between *"agent returned all Texas accounts"* and *"agent returned no results."*
    - **The `Fill using` column** (left of the Value column) controls how each input gets its value at runtime. The options include **Custom value** (the planner fills it from the conversation, guided by the description) and **dynamically filled** options that pull from variables or **outputs of an earlier tool**. The description matters in either case — when the value is dynamically filled from another tool's output, the description tells the planner *how to reshape that output* to match this input's expected format.
@@ -415,13 +414,12 @@ Open the **Account Data Lookup Agent** in Copilot Studio and walk through each o
 
 1. Select the **+** in the Test chat to start a **new conversation** so no prior context influences the planner.
 
-> [!IMPORTANT]
-> Run the following prompts in order **without resetting the conversation again** between turns. Several prompts depend on the planner remembering earlier results (e.g., "them", "the 2nd one"), and resetting partway through will break those references.
+   > [!IMPORTANT]
+   > Run the following prompts in order **without resetting the conversation again** between turns. Several prompts depend on the planner remembering earlier results (e.g., "them", "the 2nd one"), and resetting partway through will break those references.
 
-After each response, expand the **activity panel** in the test chat to see which child agent and which tool the planner chose, and what arguments it passed.
+   After each response, expand the **activity panel** in the test chat to see which child agent and which tool the planner chose, and what arguments it passed.
 
-{: start="3"}
-1. **Find accounts by location.** Uses the **Address1: State or Providence** column we indexed in Use Case #1.
+1. **Find accounts by location.** Uses the **Address 1: State/Province** column we indexed in Use Case #1.
 
     ```text
     What are the accounts in Texas?


### PR DESCRIPTION
Fixes #327.

## Summary

Addresses all six findings from the mcs-lab-auditor static audit of the new V2.1 `mcs-orchestration` lab.

| # | Severity | Fix |
|---|---|---|
| f-0001 | medium | Add `mcs-orchestration` to `lab_metadata` (order 290), `lab_journeys` (developer), `lab_orders.section.intermediate`, and `legacy_lab_orders` in `_data/lab-config.yml` |
| f-0002 | low | Drop `{: start="3"}` kramdown directive; nest the IMPORTANT alert + paragraph under step 2 so the numbered list isn't interrupted |
| f-0003 | low | Replace prereqs that the lab itself configures (Dataverse search, view edits) and remove the unused "Dataverse unbound action connector" line. Add the Account Data Lookup Agent precondition + UC#3 preview-feature note |
| f-0004 | low | Scene heading rename: "Test and Publish the Account and Contact Information Agent" → "Test and Publish the Account Data Lookup Agent" |
| f-0005 | low | "Address1: State or Providence" → "Address 1: State/Province" (3 occurrences) |
| f-0006 | low | "the account name, and/or the account name" → "the account name, and/or the primary contact name" (matches the tool's own description higher up that lists "city, account name, primary contact, state") |

## Files

- `_data/lab-config.yml` — adds the missing `lab_metadata`/`lab_journeys`/`lab_orders.section.intermediate`/`legacy_lab_orders` entries for `mcs-orchestration`. Without these the bootcamp listing has no metadata row for the lab.
- `_labs/mcs-orchestration.md` — five content fixes (f-0002 through f-0006).

## Source

Findings produced by [mcs-lab-auditor](https://github.com/microsoft/BootcampLabTestPlugin) static audit, run id `2026-05-23T1045Z-3532`.

## Test plan

- [ ] `_data/lab-config.yml` parses; `mcs-orchestration` appears in `lab_metadata`, `lab_journeys`, `lab_orders.section.intermediate`, and `legacy_lab_orders`.
- [ ] The bootcamp index page renders a tile for `mcs-orchestration` at the expected slot.
- [ ] `_labs/mcs-orchestration.md` Use Case #2 Demonstration list renders as 1...9 in both Jekyll and a plain GFM preview (no kramdown reliance).
- [ ] Use Case #1 Scene "Ensure that indexes are in place..." references "Address 1: State/Province" at all three occurrences.
- [ ] Use Case #1 scene heading reads "Test and Publish the Account Data Lookup Agent".
- [ ] Use Case #2 quoted tool description reads "city, the account name, and/or the primary contact name".