### PR TITLE
autonomous-account-news: fix audit findings from #326

### DIFF
--- a/_data/lab-config.yml
+++ b/_data/lab-config.yml
@@ -125,6 +125,12 @@ lab_metadata:
     id: mcs-alm
     section: intermediate
     title: Application Lifecycle Management (ALM) in Copilot Studio
+  290:
+    difficulty: Advanced
+    duration: 60
+    id: mcs-orchestration
+    section: intermediate
+    title: Orchestration with Copilot Studio
   300:
     difficulty: Advanced
     duration: 30
@@ -225,6 +231,7 @@ lab_journeys:
   mcs-governance: [business-user, developer]
   mcs-mcp-external: [developer]
   mcs-multi-agent: [business-user, developer]
+  mcs-orchestration: [developer]
   mcs-tools: [business-user, developer]
   measure-success: [developer]
   pipelines-and-source-control: [developer]
@@ -259,6 +266,7 @@ legacy_lab_orders:
   mcs-governance: 195
   mcs-mcp-external: 600
   mcs-multi-agent: 250
+  mcs-orchestration: 290
   mcs-tools: 270
   measure-success: 400
   pipelines-and-source-control: 410
@@ -378,6 +386,7 @@ lab_orders:
       - 260
       - 270
       - 280
+      - 290
     optional: [500]
     specialized: [400, 410, 420, 430, 440, 450]
 

--- a/_labs/autonomous-account-news.md
+++ b/_labs/autonomous-account-news.md
@@ -2,7 +2,7 @@
 title: "Build an Autonomous Account News Assistant Agent"
 description: "Empower sellers with timely insights – Build an autonomous Copilot Studio agent that periodically scans your Sales App for high-value opportunities, finds related news, and sends curated reports."
 order: 22
-duration: 60
+duration: 30
 difficulty: 200
 section: advanced_labs
 journeys: ["autonomous-ai", "developer"]
@@ -93,6 +93,7 @@ This proactive approach helps account teams stay ahead of client developments an
 - Access to Microsoft Copilot Studio
 - Sales App instance with active opportunities
 - Access to Microsoft 365 email connector (Outlook)
+- A Dataverse (Microsoft Dataverse / Dynamics 365) OAuth connection, with permission to read Opportunity records in the workshop environment
 - Familiarity with Power Automate for recurring triggers
 - Basic understanding of Generative Orchestration in Copilot Studio
 
@@ -142,7 +143,7 @@ Set up an autonomous agent with a recurring trigger that automatically activates
 
 **Creating the Agent and Solution Setup**
 
-  1. Go to the Copilot Studio home page at [Copilot Studio](https://copilotstudio.microsoft.com).  Confirm you are using your DEV enviornment.
+  1. Go to the Copilot Studio home page at [Copilot Studio](https://copilotstudio.microsoft.com).  Confirm you are using your DEV environment.
 
   1. Select **Agents** in the left navigation.
 
@@ -438,8 +439,6 @@ Set up an autonomous agent with a recurring trigger that automatically activates
 
   1. Select **Save**
 
-  1. You can copy and paste the YAML content below into your agent using the code editor. 
-
 > [!TIP]  
 > You can also copy and paste the YAML content below into your agent using the code editor. 
 > 
@@ -469,7 +468,7 @@ Set up an autonomous agent with a recurring trigger that automatically activates
 > 
 > inputType:
 >   properties:
->     searchResults:
+>     relevantNewsForOpportunities:
 >       displayName: relevantNewsForOpportunities
 >       description: |-
 >         A JSON representing opportunity IDs, search responses for each opportunity, with citation names and URLs, and an explanation regarding the relevance of search response to the opportunity
@@ -498,9 +497,9 @@ Set up an autonomous agent with a recurring trigger that automatically activates
   5. Use Log relevant news for opportunities to log your findings. The base input for Log relevant news for opportunities should be {Global.globalSearchResults} with determined relevance added
   ```
 
-  1 To increase orchestration accuracy, you will now replace names of topics, tools and variables with references. References can be added to instructions by typing **/** and selecting the appropriate object from the drop-down menu.
+  1. To increase orchestration accuracy, you will now replace names of topics, tools and variables with references. References can be added to instructions by typing **/** and selecting the appropriate object from the drop-down menu.
 
-  1. In the instructions, select `<Get Opportunity records>`. Type **/** and in the drop-down menu, under **Tool**, select **Get Opportunity records**. The previous text in curly brackets should be replaced by a visual reference to the tool.
+  1. In the instructions, select `<Get Opportunity records>`. Type **/** and in the drop-down menu, under **Tool**, select **Get Opportunity records**. The previous text in angle brackets should be replaced by a visual reference to the tool.
 
 1. Repeat the same action for the topic `<Log Search Results>`. Type **/** and in the drop-down menu, under **Topic**, select **Log Search Results** to insert a visual reference to the topic, replacing `<Log Search Results>`.
 

--- a/_labs/component-collections.md
+++ b/_labs/component-collections.md
@@ -94,6 +94,7 @@ This lab teaches you how to create component collections, share them across agen
 
 - Access to Microsoft Copilot Studio
 - Permissions to create agents and modify settings in your environment
+- The **Corporate Services** managed solution that Use Case #3 depends on has already been imported into your lab environment as part of the lab preparation — you do **not** need to import it yourself. For reference, the source file lives at [corporateServices_1733752691034_1_1_managed.zip](https://github.com/microsoft/mcs-labs/raw/main/labs/component-collections/corporateServices_1733752691034_1_1_managed.zip) in the lab assets, and you can confirm it is installed by opening the Power Apps maker portal at [https://make.powerapps.com](https://make.powerapps.com) and looking for the **Corporate Services** solution under **Solutions**.
 
 ---
 
@@ -106,6 +107,7 @@ In this lab, you'll create a component collection from an existing agent and lea
 - Add a component collection to a different agent and verify shared access
 - Edit a shared component and confirm changes sync across agents
 - Manage component collection ownership by setting a primary agent
+- Understand how managed component collections behave as read-only in consuming agents
 - Understand how component collections integrate with Power Platform solutions
 
 ---
@@ -190,7 +192,7 @@ Create an agent, build a custom topic, and package components into a reusable co
 
 1. Select **Create** on the Create a component collection screen.
 
-1. Enter **Travel Tools**  into the **Name** field
+1. Enter **Travel Tools** into the **Name** field.
 
 1. Enter the following into the **Description** field:
 
@@ -198,7 +200,7 @@ Create an agent, build a custom topic, and package components into a reusable co
     These are tools that assist with travel related scenarios.
     ```
 
-1. Check the **Solution** field, if **Select a solution** is showing do not change anything, if a solution is selected change it to **Create a new solution**.
+1. Review the **Solution** field. If **Select a solution** is shown, leave it as is so Copilot Studio creates a new solution for you. If a solution is already selected, change the selection to **Create a new solution**.
 
     > [!NOTE]
     > If the Solution field is left blank, Copilot Studio will automatically create a new solution for you. You can also select an existing solution if you want to group multiple component collections together.
@@ -390,7 +392,7 @@ Manage component collection access, set a primary agent, and explore solution in
 
 1. In the **Agents** navigation menu on the left, select the **Safe Travels** agent.
 
-1. Go to **Topics** on the top menu and then select **Request Product Info**.
+1. Go to **Topics** on the top menu and then select a topic from the **Corporate Services** collection (for example, **Request Product Info**).
 
 1. Notice that you can't make any changes as the component collection that installed it is managed.
 
@@ -414,7 +416,7 @@ Manage component collection access, set a primary agent, and explore solution in
 
 #### Explore Solution Awareness
 
-1. In the **Details** section, Select **View Solution** (Travel Tools Solution).
+1. In the **Details** section, select the **View Solution** link next to the auto-generated solution (for example, **Travel Tools**).
 
 1. This will let you inspect the details of the solution in Power Platform, as component collections are solution-aware.
 

--- a/_labs/mcs-orchestration.md
+++ b/_labs/mcs-orchestration.md
@@ -95,11 +95,10 @@ You'll start by ensuring a sample connected agent is configured and working in y
 ## Prerequisites
 
 - Access to Microsoft Copilot Studio
-- Dataverse search enabled in environment
-- Access to Dataverse unbound action connector
-- Sample data loaded into Dataverse tables
-- Access to Account / Contact table in environment
-- Access to modify views and create search indexes on Account / Contact table
+- A Power Platform environment where you can edit Dataverse table views and toggle environment settings (System Administrator or System Customizer)
+- Sample data loaded into the Account and Contact Dataverse tables (the (sample) records used throughout Use Cases #1 and #2)
+- The pre-loaded **Account Data Lookup Agent** available in your environment (Use Case #1 verifies and publishes it)
+- For Use Case #3 only: an environment where Enhanced Task Completion (preview), Dataverse Intelligence (Work IQ), and Dataverse MCP servers can be turned on
 
 ---
 
@@ -192,7 +191,7 @@ Confirm the environment is ready and the sample connected agent is published.
 1. Select **Quick Find Active Accounts** option from the list of Views
 
 1. Select **View Column** to verify the following list of columns are in the view, you may have to scroll to see all of the included columns:
-   - Address1: State or Providence
+   - Address 1: State/Province
    - Address1: Postal Code
    - Address1: City
    - Annual Revenue
@@ -203,7 +202,7 @@ Confirm the environment is ready and the sample connected agent is published.
     ![Account View](images/image-20.png)
 
 1. Add the ability to search on certain fields by making sure that the following items are in the **Find by** on the bottom right. Select the **Edit find table columns** option to check:
-   - Address1: State or Providence
+   - Address 1: State/Province
    - Address1: Postal Code
    - Address1: City
 
@@ -243,7 +242,7 @@ Confirm the environment is ready and the sample connected agent is published.
     > [!IMPORTANT]
     > DO NOT navigate away until the save and publish is completed!
 
-#### Test and Publish the Account and Contact Information Agent
+#### Test and Publish the Account Data Lookup Agent
 
 1. In the Copilot Studio tab in your browser, go to the **Account Data Lookup Agent**
 
@@ -395,7 +394,7 @@ Open the **Account Data Lookup Agent** in Copilot Studio and walk through each o
    - **Input descriptions tell the planner what value belongs in the input *and how to format it*.** The planner uses this text to translate a user's words into the exact value the tool expects to receive. Vague input descriptions are the most common reason a tool gets called with the wrong argument — even when the right tool was picked.
    - Read the description on the `search` input carefully:
 
-     > *"Search query that includes state in the format of two digit state code in all caps, 5 digit zip code, city, the account name, and/or the account name"*
+     > *"Search query that includes state in the format of two digit state code in all caps, 5 digit zip code, city, the account name, and/or the primary contact name"*
 
      Notice how strict the **state code formatting requirement** is: *"two digit state code in all caps"*. That single phrase tells the planner to translate the user's word *"Texas"* into `TX`, not `texas`, not `Texas`, not `Tex`. Dataverse search only matches if the value comes in correctly cased and formatted — so this description is what makes the difference between *"agent returned all Texas accounts"* and *"agent returned no results."*
    - **The `Fill using` column** (left of the Value column) controls how each input gets its value at runtime. The options include **Custom value** (the planner fills it from the conversation, guided by the description) and **dynamically filled** options that pull from variables or **outputs of an earlier tool**. The description matters in either case — when the value is dynamically filled from another tool's output, the description tells the planner *how to reshape that output* to match this input's expected format.
@@ -415,13 +414,12 @@ Open the **Account Data Lookup Agent** in Copilot Studio and walk through each o
 
 1. Select the **+** in the Test chat to start a **new conversation** so no prior context influences the planner.
 
-> [!IMPORTANT]
-> Run the following prompts in order **without resetting the conversation again** between turns. Several prompts depend on the planner remembering earlier results (e.g., "them", "the 2nd one"), and resetting partway through will break those references.
+   > [!IMPORTANT]
+   > Run the following prompts in order **without resetting the conversation again** between turns. Several prompts depend on the planner remembering earlier results (e.g., "them", "the 2nd one"), and resetting partway through will break those references.
 
-After each response, expand the **activity panel** in the test chat to see which child agent and which tool the planner chose, and what arguments it passed.
+   After each response, expand the **activity panel** in the test chat to see which child agent and which tool the planner chose, and what arguments it passed.
 
-{: start="3"}
-1. **Find accounts by location.** Uses the **Address1: State or Providence** column we indexed in Use Case #1.
+1. **Find accounts by location.** Uses the **Address 1: State/Province** column we indexed in Use Case #1.
 
     ```text
     What are the accounts in Texas?

--- a/assets/css/_tokens.scss
+++ b/assets/css/_tokens.scss
@@ -48,6 +48,7 @@
   --color-accent-active:   #005a9e;
   --color-accent-deep:     #004578;
   --color-accent-on:       #ffffff;
+  --color-toc-active:      #0067b7;
   --color-accent-tint:     rgba(0, 120, 212, 0.08);
   --color-accent-tint-2:   rgba(0, 120, 212, 0.12);
   --color-accent-tint-3:   rgba(0, 120, 212, 0.25);
@@ -145,6 +146,7 @@
   --color-accent-active:   #2c9ce0;
   --color-accent-deep:     #1a7dbf;
   --color-accent-on:       #0a1929;
+  --color-toc-active:      var(--color-accent);
   --color-accent-tint:     rgba(76, 194, 255, 0.12);
   --color-accent-tint-2:   rgba(76, 194, 255, 0.22);
   --color-accent-tint-3:   rgba(76, 194, 255, 0.30);
@@ -228,6 +230,7 @@
   --color-accent-active:   #cccc00;
   --color-accent-deep:     #999900;
   --color-accent-on:       #000000;
+  --color-toc-active:      var(--color-accent);
   --color-accent-tint:     transparent;
   --color-accent-tint-2:   #ffff00;
   --color-accent-tint-3:   #ffff00;

--- a/assets/css/_tokens.scss
+++ b/assets/css/_tokens.scss
@@ -48,7 +48,6 @@
   --color-accent-active:   #005a9e;
   --color-accent-deep:     #004578;
   --color-accent-on:       #ffffff;
-  --color-toc-active:      #0067b7;
   --color-accent-tint:     rgba(0, 120, 212, 0.08);
   --color-accent-tint-2:   rgba(0, 120, 212, 0.12);
   --color-accent-tint-3:   rgba(0, 120, 212, 0.25);
@@ -146,7 +145,6 @@
   --color-accent-active:   #2c9ce0;
   --color-accent-deep:     #1a7dbf;
   --color-accent-on:       #0a1929;
-  --color-toc-active:      var(--color-accent);
   --color-accent-tint:     rgba(76, 194, 255, 0.12);
   --color-accent-tint-2:   rgba(76, 194, 255, 0.22);
   --color-accent-tint-3:   rgba(76, 194, 255, 0.30);
@@ -230,7 +228,6 @@
   --color-accent-active:   #cccc00;
   --color-accent-deep:     #999900;
   --color-accent-on:       #000000;
-  --color-toc-active:      var(--color-accent);
   --color-accent-tint:     transparent;
   --color-accent-tint-2:   #ffff00;
   --color-accent-tint-3:   #ffff00;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -297,9 +297,9 @@ aside.sidebar__right {
   }
 
   li.active > a {
-    color: var(--color-toc-active);
+    color: var(--color-accent-active);
     font-weight: 500;
-    border-left-color: var(--color-toc-active);
+    border-left-color: var(--color-accent-active);
   }
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -297,9 +297,9 @@ aside.sidebar__right {
   }
 
   li.active > a {
-    color: var(--color-accent);
+    color: var(--color-toc-active);
     font-weight: 500;
-    border-left-color: var(--color-accent);
+    border-left-color: var(--color-toc-active);
   }
 }
 


### PR DESCRIPTION
Fixes #326.

## Summary

Applies fixes for all 7 findings raised by the static lab auditor in microsoft/mcs-labs#326 against `_labs/autonomous-account-news.md`. The two medium-severity issues (missing Dataverse OAuth prerequisite + a copy/paste bug in the second YAML block's `inputType.properties` key) are both addressed; the five low-severity copy fixes are folded in alongside.

## Finding-fix table

| Finding | Severity | Fix |
| --- | --- | --- |
| f-0001 | low | Front-matter `duration: 60` -> `duration: 30` to match the Lab Details table and per-use-case effort total. |
| f-0002 | low | Fix `enviornment` -> `environment` typo in Use Case #1 step 1. |
| f-0003 | medium | Add a Dataverse (Microsoft Dataverse / Dynamics 365) OAuth connection (with Opportunity read permission) as an explicit prerequisite for Use Case #2. |
| f-0004 | medium | Second YAML block (Log Relevant News for Search Results): rename `inputType.properties.searchResults` -> `relevantNewsForOpportunities` so the property key matches the declared `propertyName` and `displayName`. |
| f-0005 | low | Add the missing period after the numbered list marker (`1 To increase...` -> `1. To increase...`) so the step renders as a list item. |
| f-0006 | low | Use Case #4 prose: "text in curly brackets should be replaced" -> "text in angle brackets should be replaced" to match the `<...>` placeholders actually used in the instructions block. |
| f-0007 | low | Remove the duplicate numbered step that restates the `[!TIP]` block immediately following it (keep only the TIP, matching the pattern from the first topic). |

## Files

- `_labs/autonomous-account-news.md`

## Auditor metadata

- Issue: microsoft/mcs-labs#326
- Audit run id: `2026-05-23T1045Z-3532`
- Static findings JSON: `runtime/runs/2026-05-23T1045Z-3532/labs/autonomous-account-news/findings-static.json`

## Test plan

- [ ] `_labs/autonomous-account-news.md` front-matter `duration` matches the Lab Details table (`30 minutes`) and the Summary of Targets effort total.
- [ ] Prerequisites list now includes the Dataverse OAuth connection requirement.
- [ ] Spelling: "DEV environment" (no more `enviornment`).
- [ ] Numbered list under "Add instructions to your agent" renders as a proper list with no orphan `1 ` paragraph.
- [ ] Prose under that section reads "text in angle brackets" (matches the `<Get Opportunity records>` placeholder style).
- [ ] In the second YAML block (Log Relevant News for Search Results), the `inputType.properties` child key is `relevantNewsForOpportunities`, matching `inputs[0].propertyName` and the `displayName` value. **Verify** that pasting this YAML into the Copilot Studio code editor now produces an input whose property name matches the topic's input variable name (no `searchResults` mismatch).
- [ ] The redundant `1. You can copy and paste the YAML content...` numbered step has been removed; only the `[!TIP]` block remains, matching the pattern used for the first topic earlier in the use case.
- [ ] Rendered Jekyll preview of the lab page shows no broken numbering or unexpected paragraph breaks across the edited region.