### PR TITLE
agent-builder-m365: linkify every PDF reference in upload steps

### DIFF
--- a/_labs/agent-builder-m365.md
+++ b/_labs/agent-builder-m365.md
@@ -578,7 +578,7 @@ Use the Researcher agent to perform two deep-analysis tasks on a complex PDF doc
 
 1. (Recommended) In the Researcher chat header (top right), click the **mode picker pill** (defaults to **Auto**) and switch to **Critique** (`GPT responses, refined by Claude (Frontier)`). Critique mode produces more reliable convergence on long PDFs than Auto in the current product. The other options (`Model Council`, `Claude`) are also valid but tend to be slower.
 
-1. Upload the **Contoso_Grand_Hotel_Performance_Report.pdf** by clicking the **+** (Add and manage sources) button next to the message input, choosing **Upload images and files**, and selecting the file from your local machine. Wait for the upload confirmation before continuing.
+1. Upload the [**Contoso_Grand_Hotel_Performance_Report.pdf**](https://github.com/microsoft/mcs-labs/raw/main/labs/agent-builder-m365/Contoso_Grand_Hotel_Performance_Report.pdf) by clicking the **+** (Add and manage sources) button next to the message input, choosing **Upload images and files**, and selecting the file from your local machine. Wait for the upload confirmation before continuing.
 
 #### Prompt 1: Executive briefing with root-cause analysis
 
@@ -665,10 +665,10 @@ Use the Analyst agent to perform a detailed ROI analysis with NPV, IRR, and disc
     > [!TIP]
     > The Analyst agent is another **frontier agent** in Microsoft 365 Copilot. While Researcher excels at reasoning and synthesis, Analyst is purpose-built for **data-heavy work** — extracting tables from documents, performing calculations, building models, generating visualizations, and producing structured outputs like Excel files. Think of Researcher as your strategic advisor and Analyst as your financial modeler.
 
-3. Upload the **Contoso_Grand_Hotel_Performance_Report.pdf** by selecting the **+** (Add and manage sources) button next to the message input, choosing **Upload images and files**, and selecting the same PDF you downloaded earlier.
+3. Upload the [**Contoso_Grand_Hotel_Performance_Report.pdf**](https://github.com/microsoft/mcs-labs/raw/main/labs/agent-builder-m365/Contoso_Grand_Hotel_Performance_Report.pdf) by selecting the **+** (Add and manage sources) button next to the message input, choosing **Upload images and files**, and selecting the same PDF you downloaded earlier. (If you don't still have it, the [download link](https://github.com/microsoft/mcs-labs/raw/main/labs/agent-builder-m365/Contoso_Grand_Hotel_Performance_Report.pdf) is here too.)
 
 > [!NOTE]
-> You're using the same PDF from Use Case #3, but with a completely different agent. This demonstrates how different frontier agents can extract different types of value from the same source document.
+> You're using the [same PDF](https://github.com/microsoft/mcs-labs/raw/main/labs/agent-builder-m365/Contoso_Grand_Hotel_Performance_Report.pdf) from Use Case #3, but with a completely different agent. This demonstrates how different frontier agents can extract different types of value from the same source document.
 
 #### Run the financial analysis prompt
 
@@ -758,7 +758,7 @@ In this section, you'll upload the same Contoso PDF to the Cowork agent, ask it 
 
 ### Objective
 
-Use the Cowork agent to read the same PDF report you uploaded to Researcher, identify five operational issues with root causes and recommendations, and have Cowork draft a real Outlook email to a named recipient (Dewain Robinson).
+Use the Cowork agent to read the [same PDF report](https://github.com/microsoft/mcs-labs/raw/main/labs/agent-builder-m365/Contoso_Grand_Hotel_Performance_Report.pdf) you uploaded to Researcher, identify five operational issues with root causes and recommendations, and have Cowork draft a real Outlook email to a named recipient (Dewain Robinson).
 
 ---
 
@@ -779,7 +779,7 @@ Use the Cowork agent to read the same PDF report you uploaded to Researcher, ide
 
 #### Upload the report and ask Cowork to draft an email
 
-1. Click **Add attachments** (the paperclip icon next to the message input), then choose **Upload images and files (PDF, Word, Excel, images)**. Select the `Contoso_Grand_Hotel_Performance_Report.pdf` file you downloaded for Use Case #3.
+1. Click **Add attachments** (the paperclip icon next to the message input), then choose **Upload images and files (PDF, Word, Excel, images)**. Select the [`Contoso_Grand_Hotel_Performance_Report.pdf`](https://github.com/microsoft/mcs-labs/raw/main/labs/agent-builder-m365/Contoso_Grand_Hotel_Performance_Report.pdf) file you downloaded for Use Case #3 (or [download it](https://github.com/microsoft/mcs-labs/raw/main/labs/agent-builder-m365/Contoso_Grand_Hotel_Performance_Report.pdf) again if you no longer have it locally).
 
 1. Wait for the upload to complete — the PDF will appear as a chip above the message input.
 


### PR DESCRIPTION
Small follow-up to #342: every mention of the Contoso Grand Hotel Performance Report in the UC3 / UC4 / UC5 upload-action lines now hyperlinks to the canonical download URL, so learners who skip ahead, lose the page, or come back to UC4 / UC5 later can grab the file in-place instead of scrolling back to the UC3 download section.

## What changed

| Location | Before | After |
|---|---|---|
| UC3 upload step | `**Contoso_Grand_Hotel_Performance_Report.pdf**` | linked to the raw URL |
| UC4 upload step | `**Contoso_Grand_Hotel_Performance_Report.pdf**` ... "same PDF you downloaded earlier" | linked + added a "if you don't still have it, here's the download link" fallback |
| UC4 NOTE block | "same PDF from Use Case #3" | linked |
| UC5 objective | "the same PDF report you uploaded to Researcher" | linked |
| UC5 upload step | `` `Contoso_Grand_Hotel_Performance_Report.pdf` `` ... "for Use Case #3" | linked + fallback download link |

Narrative mentions inside prose paragraphs, scenario blurbs, and the verbatim text *inside* prompt code blocks are intentionally left alone — only the actionable references are linkified.

## Rationale

User feedback on the published lab: "Anytime we reference the PDF that is to be downloaded, you should make it a link so that people don't accidentally skip over and have to go back to get the link."