### PR TITLE
agent-builder-m365: UC#5 — force Cowork to use the Outlook draft tool

### DIFF
--- a/_labs/agent-builder-m365.md
+++ b/_labs/agent-builder-m365.md
@@ -786,7 +786,7 @@ Use the Cowork agent to read the [same PDF report](https://github.com/microsoft/
 1. Paste the following prompt into the message input and press **Send**:
 
     ```text
-    Draft a professional email to Dewain Robinson summarizing the five most urgent operational issues from the attached hotel performance report.
+    Create a draft email in my Outlook mailbox addressed to Dewain Robinson summarizing the five most urgent operational issues from the attached hotel performance report. Use the Outlook draft tool — do not just write the email text in chat.
 
     For each issue, include in one short bullet: the symptom, the root cause, the estimated financial impact, and the matching recommendation (Section 16 R-number).
 


### PR DESCRIPTION
## Summary

- Updates the UC#5 Cowork prompt so Cowork actually creates an Outlook draft instead of writing the email inline in chat.
- The new wording opens with **"Create a draft email in my Outlook mailbox"** and explicitly says **"Use the Outlook draft tool — do not just write the email text in chat."**

## Why

Live audit observed Cowork satisfying the original prompt ("Draft a professional email to Dewain Robinson…") by writing the email text inline in the chat reply only. No Outlook draft was created, which breaks the lab's subsequent **"Verify the draft in Outlook"** scene — learners get to step 1 of that scene, open Outlook → Drafts, and find nothing there.

Cowork is agentic by design, but it follows the verb in the prompt. "Draft … email" is ambiguous (it can mean either "compose text" or "invoke draft tool"). Naming the Outlook draft tool explicitly is what routes Cowork to its `draft_email_in_outlook` capability.

## Verification

Re-ran UC#5 with the updated prompt against the workshop tenant (`user.2sypp5l9@copilotstudiotraining.onmicrosoft.com`):

- Cowork's streaming now shows **"Searching people for Dewain Robinson"** and **"Drafting email to dewain.robinson@copilotstudiotraining.onmicrosoft.com — [Outlook]"** as intermediate steps.
- Final chat reply: **"Your draft to Dewain Robinson is saved in your Drafts folder."**
- Outlook Drafts folder now contains the draft, with all five R1-R5 bullets, the "Hi Dewain," greeting, and "The Operations Team" sign-off.

## Test plan

- [ ] Re-run UC#5 end-to-end on a fresh workshop account and confirm the draft appears in Outlook → Drafts within ~3 minutes of sending the prompt.
- [ ] Verify the recipient pill resolves to a real workshop tenant identity (synthetic Dewain Robinson is seeded in the bootcamp tenant).
- [ ] Confirm the inline chat reply still ends with the "Open it in Outlook to review, edit, or send" phrase the lab promises.

## Scope

Single-line change to one numbered step in `_labs/agent-builder-m365.md`. No structural changes, no impact on other use cases.

A separate PR follows with the rest of the UC drift fixes uncovered by the same audit run.