### PR TITLE
core-concepts-agent-knowledge-tools: fix UI drift + code-block spacing from #347

### DIFF
--- a/_labs/core-concepts-agent-knowledge-tools.md
+++ b/_labs/core-concepts-agent-knowledge-tools.md
@@ -160,16 +160,22 @@ Create a fully configured Copilot Studio agent with clear instructions and Claud
 
 1. Navigate to [Microsoft Copilot Studio](https://copilotstudio.microsoft.com) and sign in with your credentials.
 
-1. On the Copilot Studio **Home** page, locate the **Describe your agent in your own words** box (the inline agent creation form).
+   > [!NOTE]
+   > On a first sign-in (especially for workshop / fresh-tenant accounts) you may see two one-time dialogs before reaching the home page:
+   > 1. **Welcome to Microsoft Copilot Studio** — choose a country/region (e.g. **United States**) and select **Get Started**. The marketing-opt-in checkbox is optional.
+   > 1. **Welcome to Copilot Studio!** — a 4-step product tour. Click **Skip** (or step through with **Next**) to dismiss it.
+
+1. On the Copilot Studio **Home** page, under the heading **What would you like to build?**, locate the inline agent-creation textbox (placeholder _"Start building by describing what your agent needs to do"_). The **Agent** tab should be selected by default.
 
    > [!NOTE]
-   > If you don't see the inline **Describe your agent** box, your environment may not support agent creation by using natural language. In that case, select **Create** (or **+ New agent**) from the left navigation, then choose the **Describe** option to reach the same form.
+   > If you don't see the inline agent-creation textbox on the home page, your environment may not support agent creation by using natural language. In that case, select **Create** (or **+ New agent**) from the left navigation, then choose the **Describe** option to reach the same form.
 
 1. In the agent creation form, provide the following information and select **Send**:
 
    ```
    Provide information and guidance on how to use Copilot Studio and prompt engineering.
    ```
+
 1. Wait for the "Your agent has been provisioned." notification.
 
 1. In the Details pane, select **Edit**
@@ -451,9 +457,11 @@ Create and configure two tools that extend your agent's capabilities beyond simp
    ```
 
 1. When the agent asks for a location, respond:
+
    ```
    Orlando
    ```
+
 1. Review the weather information returned by the agent. Notice how it uses the tool to fetch real-time data. Also notice that the agent automatically used the **Imperial** or **Metric** unit you selected earlier without asking the user — this is because you set that input to a custom value instead of letting the AI fill it dynamically.
 
    > [!TIP]
@@ -477,6 +485,7 @@ Create and configure two tools that extend your agent's capabilities beyond simp
    ```
    Analyze this prompt (replace with text) based upon the CARE Prompt Guidance to determine what are recommendations on how to improve writing the prompt and if it is very good. Respond using markdown language bolding and using bullets to make the answer more visually appealing to the user.
    ```
+
 1. In the instructions you just pasted select ** (replace with text)**.
 
 1. With ** (replace with text)** still selected, in the lower left of the dialog, select **Add content**
@@ -651,7 +660,8 @@ Create a custom topic that handles a specific user intent (mailing list signup) 
 
 1. Check your nodes and if you don't already have a node that thanks the user then select + after the last node and select a **Message** node.
 
-1. Input the following as the message
+1. Input the following as the message:
+
    ```
    Thank you! Your information has been recorded. (In production, this would submit to the mailing list system.)
    ```


### PR DESCRIPTION
Closes #347.

## Summary

Applies fixes for the 6 findings reported by `mcs-lab-auditor` run `2026-05-25T0740Z-622d` against the `core-concepts-agent-knowledge-tools` lab. Interactive (Playwright) coverage exercised **Use Case #1, steps 1–4** against a live workshop tenant; the static phase covered the whole lab markdown.

## Findings → fixes

| # | Severity | Finding | Fix |
|---|---|---|---|
| 1 | medium | UC1 step 2 references the textbox label *"Describe your agent in your own words"*, but the live Copilot Studio home page now shows heading **What would you like to build?** + placeholder **Start building by describing what your agent needs to do**. | Rewrote step 2 to reference the current heading + placeholder. Also updated the fallback `[!NOTE]` to use neutral *"inline agent-creation textbox"* language so it survives the next placeholder change. |
| 2 | low | UC1 step 1: no instruction for the one-time **Welcome to Microsoft Copilot Studio** region / Terms-of-Use modal that workshop / fresh-tenant accounts always hit on first sign-in. | Added a `[!NOTE]` under step 1 explaining the region modal (pick region, click **Get Started**, marketing checkbox is optional). |
| 3 | low | UC1: no instruction for the **Welcome to Copilot Studio!** 4-step product tour that appears immediately after the region modal. | Folded into the same step-1 `[!NOTE]`: dismiss with **Skip** (or step through with **Next**). |
| 4 | low | UC3 *Test the Weather Tool* step 3 (line 453): missing blank line between list-item prose and the opening code fence. | Inserted blank lines before and after the *"Orlando"* code block to match the convention used elsewhere in the lab. |
| 5 | low | Lines 172 and 479: closing code fence directly followed by the next list item with no blank separator. | Inserted blank lines after both closing fences. |
| 6 | low | UC4 *Create a Topic with Description* line 654: missing blank line before the message-node code fence, and the lead-in line lacks the trailing colon every other *"Input the following…"* step uses. | Added trailing colon + blank line. |

No findings were skipped — all 6 were in scope and had unambiguous corrections.

## Files changed

- `_labs/core-concepts-agent-knowledge-tools.md` — 13 insertions, 3 deletions.

## Test plan

- [ ] Render `_labs/core-concepts-agent-knowledge-tools.md` (Jekyll preview or GitHub markdown view) and confirm:
  - [ ] Use Case #1 → *Create Your Agent* step 1 has a NOTE block describing both first-sign-in dialogs (region modal + 4-step coachmark tour).
  - [ ] Use Case #1 → *Create Your Agent* step 2 reads *"under the heading **What would you like to build?**, locate the inline agent-creation textbox (placeholder _Start building by describing what your agent needs to do_)"*.
  - [ ] The fallback NOTE for tenants without the inline form still renders right after the new step 2.
  - [ ] UC3 → *Test the Weather Tool* "Orlando" code block has blank lines above and below.
  - [ ] UC4 → *Create a Topic with Description* "Thank you!" message-node step reads *"Input the following as the message:"* (with colon) and the code block is separated by a blank line.
- [ ] Optional: re-run `/audit-lab core-concepts-agent-knowledge-tools` against a fresh workshop account; the live-UI findings should no longer reproduce.

## Audit-coverage caveat

The interactive phase stopped at UC1 step 4 (agent provisioning) at the user's request. **UC1 steps 5–14 and Use Cases #2–#4 were not exercised against the live UI in this run** — the model picker, Knowledge / Generative AI settings, *Set Knowledge Source as Official*, MSN Weather connector setup, custom Prompt-Analyzer flow, and topic-from-description flow may all have additional UI drift that a future re-audit would catch. This PR addresses only what the current run confirmed.