### PR TITLE
core-concepts-agent-knowledge-tools: fix UI drift from interactive audit #349

### DIFF
--- a/_labs/core-concepts-agent-knowledge-tools.md
+++ b/_labs/core-concepts-agent-knowledge-tools.md
@@ -188,14 +188,14 @@ Create a fully configured Copilot Studio agent with clear instructions and Claud
 
 1. Select the dropdown for the agent's model.  Ensure that Claude Sonnet 4.6 is selected.   
   
-1. Review the Instructions pane details, this prompt was created by Copilot Studio from your initial description. It should basically tell the agent to "Help users write prompts, create PowerFX formulas, and with navigating Copilot Studio features."
+1. Review the **Instructions** pane. Copilot Studio generated a structured prompt from your initial description, organized into sections such as **Purpose**, **General Guidelines**, **Skills**, **Step-by-Step Instructions**, and **Interaction Examples**. The exact wording varies per generation, but the agent should focus on helping users with **Copilot Studio** and **prompt engineering** — the two topics from your description.
 
    > [!TIP]
    > Clear, specific instructions help your agent understand its role and provide consistent responses. Think of instructions as the agent's job description.
 
 1. Scroll down to the **Knowledge** section and select **Add Knowledge**.
 
-1. Select Public website from the list of knowledge source options.
+1. Select **Public websites** from the list of knowledge source options.
 
 1. Input the following URL and select **Add**
 
@@ -276,7 +276,7 @@ Add a document knowledge source to your agent and verify that it accurately answ
 
 1. Download the [Copilot Studio Licensing Guide (April 2026)](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/bade/documents/products-and-services/en-us/microsoft-365/Microsoft-Copilot-Studio-Licensing-Guide-April-2026.pdf). Just make sure you have the file local on your computer.
 
-1. Select **+Add Knowledge** and select **Upload files** and use the file dialog to locate and select your downloaded license guide file from your local computer.
+1. Select **+ Add knowledge** and select the **Upload file** option (the large drop-zone tile at the top of the Featured list). Click **select to browse** and use the file dialog to locate and select your downloaded license guide file from your local computer.
 
    > [!TIP]
    > You can upload multiple file types including PDF, Word documents (.docx), PowerPoint (.pptx), and text files. Each file can be up to 512 MB.
@@ -308,9 +308,9 @@ The Use information from the web setting is available on the Generative AI setti
 
 #### Disable Ungrounded Responses
 
-1. Select the **Settings** tab at the top of the agent, then select the **Generative AI** menu.
+1. Select the **Settings** button at the top right of the agent (next to **Publish**). The Settings panel opens with **Generative AI** selected by default; if it isn't selected, choose **Generative AI** from the left navigation.
 
-1. Turn off the **Allow Ungrounded responses** setting.
+1. Scroll to the **Knowledge** section of the Generative AI settings page and turn off the **Allow ungrounded responses** toggle.
 
 1. Select **Save** to apply the change.
 


### PR DESCRIPTION
Closes #349.

## Summary

Applies the 5 findings from `mcs-lab-auditor` run `2026-05-25T0819Z-0578` — an interactive continuation that drove UC1 steps 5–14 and UC2 Scenes 3, 4, 6 against the live Copilot Studio UI, picking up where the prior PR #348 (run `2026-05-25T0740Z-622d`) left off.

## Findings → fixes

| # | Severity | Finding | Fix |
|---|---|---|---|
| 1 | low | UC1 step 8 promises the auto-generated Instructions will mention *"PowerFX formulas"* — they don't (and shouldn't; the user's input description never mentions Power Fx). | Rewrote step 8 to describe the auto-generated Instructions by structural shape (Purpose / General Guidelines / Skills / Step-by-Step / Interaction Examples) rather than a specific token-level quote. |
| 2 | low | UC1 step 10 says **Public website** (singular); live UI button reads **Public websites** (plural). UC2 step 13 already used the plural form. | Changed UC1 step 10 to **Public websites** for consistency. |
| 3 | low | UC2 step 3 says **Upload files** (plural); live UI label is **Upload file** (singular). | Reworded to use **Upload file** + a hint to click **select to browse** to open the file dialog. |
| 4 | low | UC2 Scene 4 step 1 calls Settings a *"tab at the top of the agent"* — it's a **button** in the agent action bar (next to Publish), not a tab. Settings also lands on **Generative AI** by default. | Reworded to direct learners to the **Settings** button next to **Publish**, with a note that **Generative AI** is selected by default. |
| 5 | low | UC2 Scene 4 step 2 says **Allow Ungrounded responses** (capital U); live UI uses lowercase **ungrounded**. | Lowercased *"ungrounded"* and added a hint that the toggle lives under the **Knowledge** section of the Generative AI settings page. |

## Files changed

- `_labs/core-concepts-agent-knowledge-tools.md` — 5 insertions, 5 deletions.

## Test plan

- [ ] Render `_labs/core-concepts-agent-knowledge-tools.md` (Jekyll preview or GitHub markdown view) and confirm:
  - [ ] UC1 step 8 no longer mentions "PowerFX formulas" and instead describes the auto-generated Instructions by section.
  - [ ] UC1 step 10 reads "**Public websites**" (plural) matching UC2 step 13 and the live UI.
  - [ ] UC2 *Add Document Knowledge Source* step 3 reads "**Upload file**" with the **select to browse** hint.
  - [ ] UC2 *Disable Ungrounded Responses* step 1 reads "**Settings** button at the top right of the agent (next to **Publish**)" — not "tab".
  - [ ] UC2 *Disable Ungrounded Responses* step 2 reads "**Allow ungrounded responses**" (lowercase 'u') under the **Knowledge** section of the Generative AI settings page.

## Audit-coverage caveat

This audit run intentionally **did not** exercise:

- **UC2 Scenes 1, 2, 5, 7** — these depend on uploading the licensing PDF. The Playwright MCP couldn't trigger Copilot Studio's hidden-input file picker (audit-tool limitation, not a lab bug). These scenes may still contain UI drift that a future audit — or a human review — could catch.
- **UC3 (Tools / MSN Weather connector / Prompt Analyzer)** — not exercised.
- **UC4 (Topics)** — not exercised.

A follow-up audit that addresses the file-picker limitation (e.g. via Playwright's `setInputFiles` directly on a hidden input) and exercises UC3 + UC4 is recommended to complete coverage.