### PR TITLE
core-concepts-agent-knowledge-tools: fix UC3/UC4 UI drift from interactive audit #351

### DIFF
--- a/_labs/core-concepts-agent-knowledge-tools.md
+++ b/_labs/core-concepts-agent-knowledge-tools.md
@@ -425,11 +425,14 @@ Create and configure two tools that extend your agent's capabilities beyond simp
 
 1. Select **Add a tool** and review the Tools page to understand the available options for creating new tools.
 
-1. Select **Connector** as the tool type (or browse available connectors).
+1. The Add tool dialog opens with a list of suggested connector actions. Either type **MSN Weather** in the search box at the top of the dialog (and press Enter), or click the **Connector** filter chip above the results table to narrow the list to connectors.
 
-1. Search for and in the **MSN Weather** connector section select the **Get current weather** action.
+   > [!NOTE]
+   > The **Create new** tile list at the top of the dialog (Agent flow, Prompt, Model Context Protocol, Computer use) is for net-new tool types — not for selecting an existing connector. Use the search box or the **Connector** filter instead.
 
-1. For the Connection, select **Create new connection**.
+1. In the **MSN Weather** connector section, select the **Get current weather** action.
+
+1. The connector configuration page opens with a **Connection** field labeled **Not connected**. Click that button to open the connection picker, then select **Create new connection** from the popover.
 
 1. When prompted, select **Create** to create the connection.
 
@@ -477,6 +480,9 @@ Create and configure two tools that extend your agent's capabilities beyond simp
 1. Select **Add tool** to add another tool.
 
 1. In the **Create new** section, select **Prompt**.
+
+   > [!NOTE]
+   > The first time you open the Prompt builder, a **Define your intent** product tour (1 of 3) appears as a coachmark overlay. Click **X** to dismiss it (or step through with **Next**) before continuing.
 
 1. Select the current name e.g., **Custom prompt...** at the top left and change the name to **Prompt Analyzer**.
 


### PR DESCRIPTION
Closes #351.

## Summary

Applies the 3 findings from `mcs-lab-auditor` run `2026-05-25T0838Z-4dc3`, which exercised **UC3 Scene 1 (MSN Weather connector)** and **UC4 Scene 1 (Topic from description)** against the live Copilot Studio UI for the first time. (Prior runs had only covered UC1 + UC2.)

## Findings → fixes

| # | Severity | Finding | Fix |
|---|---|---|---|
| 1 | low | UC3 step 4 said *"Select Connector as the tool type"*, but Connector is **not** in the Add tool dialog's "Create new" list — it's a filter chip / row badge. Learners get stuck. | Reworded to direct learners to either search for **MSN Weather** in the dialog's search box, or click the **Connector** filter chip above the results. Added a `[!NOTE]` clarifying that the Create new tiles (Agent flow / Prompt / Model Context Protocol / Computer use) are for net-new tool types, not for selecting an existing connector. |
| 2 | low | UC3 step 6 said *"For the Connection, select Create new connection"*, but the Connection field shows a **Not connected** button that opens a popover containing the **Create new connection** link. | Reworded step 6 to call out the **Not connected** button and the popover-driven flow. |
| 3 | low | UC3 Scene 3 step 4 (Prompt builder): on first launch a **Define your intent · 1 of 3** coachmark tour appears that the lab does not mention. | Added a `[!NOTE]` under step 4 describing the tour and how to dismiss it (click **X** or step through with **Next**). |

## Files changed

- `_labs/core-concepts-agent-knowledge-tools.md` — 9 insertions, 3 deletions.

## Test plan

- [ ] Render `_labs/core-concepts-agent-knowledge-tools.md` (Jekyll preview or GitHub markdown view) and confirm:
  - [ ] UC3 *Navigate to Tools* step 4 reads about typing **MSN Weather** in the search box / clicking the **Connector** filter chip, with a NOTE explaining the Create new list.
  - [ ] UC3 *Navigate to Tools* step 6 explicitly calls out the **Not connected** button → popover flow.
  - [ ] UC3 *Create a Custom Prompt Analyzer Tool* step 4 has a NOTE about the **Define your intent** product tour.

## Audit-coverage caveat

UC3 Scenes 2, 4, 5 (tests + agent-level instructions) and UC4 Scene 2 (test the mailing topic) were not exercised in this run — they depend on non-deterministic LLM-generated content. UC3 Scene 3 was only partially exercised: the Prompt builder dialog was opened (which is how Finding 3 was caught), but the full 18-step prompt-construction flow was not completed (Playwright cannot reliably interact with the slash-mention input pattern; the Prompt Analyzer tool was not saved). A future audit pass focused on those scenes may surface additional findings.