### PR TITLE
core-concepts-variables-agents-channels: fix UI drift + code-block spacing from audit #353

### DIFF
--- a/_labs/core-concepts-variables-agents-channels.md
+++ b/_labs/core-concepts-variables-agents-channels.md
@@ -174,12 +174,14 @@ Understand variable types, properties, scope, and behavior by exploring the exis
     > [!NOTE]
     > If you don't have this topic, you can explore variables in any existing topic that has question nodes.
 
+    > [!NOTE]
+    > When you open a topic that was created via **Add from description with Copilot**, an **Edit with Copilot** side panel opens by default. You don't need it for this exploration use case — close it via the **X** in its upper-right corner to get a clear view of the canvas.
+
 #### Review Existing Variables
 
-1. Find the **Question** node where the user's email address is collected.
+1. Find the first **Question** node (the one where the user's email address is collected). Click the node so the details panel opens on the right side of the canvas — the auto-created variable is shown there, not on the node card itself. (The node card displays the placeholder text **Select a variable** under **Save user response as**, which is misleading — the variable is bound; you just have to open the details panel to see its name and type.)
 
-
-1. Look for the **Save response as**  section. Notice that Copilot Studio automatically created a variable to store the email address when the question node was built.
+1. Look for the **Save user response as** section. Notice that Copilot Studio automatically created a variable (e.g. `EmailAddress`) to store the email address when the question node was built.
 
 1. Note the variable name (likely something like `EmailAddress` or `userEmail`).
 
@@ -316,6 +318,7 @@ Create a specialized child agent and configure the parent agent to orchestrate c
 1. Enter  **CARE Prompt Guidance** in the **Name** field.
 
 1. Input the following for the **Description**
+
     ```
     This agent provides information on the CARE Prompt guidance.
     ```
@@ -325,9 +328,13 @@ Create a specialized child agent and configure the parent agent to orchestrate c
 
 1. Select  **Save** to initialize the child agent.
 
+    > [!NOTE]
+    > You may see a **Save agent with errors?** confirmation dialog with the message *"This agent has (1) error"*. This is expected — the error is the missing **Instructions**, which you'll add in the next section. Click **Save** in the confirmation to proceed.
+
 #### Configure Child Agent Instructions
 
 1. Once save of the child agent has completed, input the following into the **Instructions** section.
+
     ```
     This agent should help users with understanding information about the prompt guidance framework and how they can leverage it to make their agents better.
     ```
@@ -481,12 +488,13 @@ Deploy your agent to Teams and Microsoft 365 Copilot channels with proper config
 1. In your Copilot Studio agent, select **Channels** in the top navigation bar.
 
 1. Review the Channels overview page to see available channel options:
-   - **Microsoft Teams**: Native Teams integration
+   - **Microsoft 365 and Microsoft Teams**: Native Teams + Microsoft 365 Copilot integration (this is the tile you'll deploy to later in this use case)
    - **Demo website**: Test website for quick agent testing
-   - **Custom website**: Embeddable web widget for your sites
-   - **Mobile app**: iOS and Android integration
-   - **Custom channel**: Direct Line API for custom applications
-   - Additional channels may include Facebook, Slack, etc.
+   - **SharePoint**: Deploy as a SharePoint-grounded agent
+   - **Web app**: Embeddable web widget for your sites
+   - **Native app**: iOS and Android integration
+   - **Direct Line Speech** / **Email** / **Dynamics 365 Customer Service** / **Genesys** / **LivePerson**: Specialized service channels
+   - Social / messaging: **Facebook**, **WhatsApp**, **Slack**, **Telegram**, **Twilio**, **Line**, **GroupMe**
 
     > [!NOTE]
     > Available channels depend on your Copilot Studio license and environment settings. Some channels require additional configuration or premium licenses.

--- a/_labs/core-concepts-variables-agents-channels.md
+++ b/_labs/core-concepts-variables-agents-channels.md
@@ -328,9 +328,6 @@ Create a specialized child agent and configure the parent agent to orchestrate c
 
 1. Select  **Save** to initialize the child agent.
 
-    > [!NOTE]
-    > You may see a **Save agent with errors?** confirmation dialog with the message *"This agent has (1) error"*. This is expected — the error is the missing **Instructions**, which you'll add in the next section. Click **Save** in the confirmation to proceed.
-
 #### Configure Child Agent Instructions
 
 1. Once save of the child agent has completed, input the following into the **Instructions** section.

--- a/_labs/core-concepts-variables-agents-channels.md
+++ b/_labs/core-concepts-variables-agents-channels.md
@@ -326,11 +326,9 @@ Create a specialized child agent and configure the parent agent to orchestrate c
     > [!NOTE]
     > The description helps the parent agent understand when to route conversations to this child agent. Be specific and clear.
 
-1. Select  **Save** to initialize the child agent.
-
 #### Configure Child Agent Instructions
 
-1. Once save of the child agent has completed, input the following into the **Instructions** section.
+1. Input the following into the **Instructions** section.
 
     ```
     This agent should help users with understanding information about the prompt guidance framework and how they can leverage it to make their agents better.
@@ -339,7 +337,10 @@ Create a specialized child agent and configure the parent agent to orchestrate c
     > [!TIP]
     > Child agent instructions should be focused and specific to their domain of expertise. Avoid generic instructions - be precise about what this agent knows and does.
 
-1. Select  **Save** to apply the instruction changes to the agent.
+1. Select **Save** to create the child agent with its name, description, and instructions.
+
+    > [!NOTE]
+    > Save the child agent only after you've entered the **Name**, **Description**, and **Instructions** — saving earlier triggers a *"Save agent with errors? (1 error)"* validation dialog because **Instructions** is a required field.
 
 #### Add Knowledge Sources to Child Agent
 


### PR DESCRIPTION
Closes #353.

## Summary

Applies the 7 findings from `mcs-lab-auditor` run `2026-05-25T1219Z-04ea` which exercised **UC1 (Variables exploration)**, **UC2 (Child Agent creation)**, and **UC3 Scene 1 (Channels overview)** against the live Copilot Studio UI for lab 3.

## Findings → fixes

| # | Severity | Finding | Fix |
|---|---|---|---|
| 1 | medium | UC3 *Navigate to Channels* step 2 bullet list lists tiles that don't exist by those names — *Microsoft Teams*, *Custom website*, *Mobile app*, *Custom channel* have all been renamed/restructured in the live UI. | Rewrote the bullet list to match the actual tiles (**Microsoft 365 and Microsoft Teams**, **Web app**, **Native app**, etc.) and surface the additional channels (**SharePoint**, **Direct Line Speech**, **Email**, **Dynamics 365 Customer Service**, **Genesys**, **LivePerson**) that are visible in the UI. |
| 2 | low | UC1 step 2 said *Save response as* — the live UI label is **Save user response as**. | Updated step 2 to use the live label + example variable name (`EmailAddress`). |
| 3 | low | Opening a topic created via *Add from description with Copilot* (lab 2 UC4) auto-opens an **Edit with Copilot** side panel that the lab doesn't mention — especially disruptive given the [!WARNING] block telling learners not to modify anything. | Added a NOTE after step 4 telling learners to close the Edit with Copilot panel before exploring. |
| 4 | low | UC1 step 1/2 fail to call out that the Question node card shows **Select a variable** as the bound-variable control label, even when an auto-created variable is already bound. Variable is only visible in the node's details panel. | Reworded step 1 to instruct clicking the node, and explain that the card's *Select a variable* label is misleading. |
| 5 | low | UC2 *Create a Child Agent* step 6 said *Save to initialize the child agent* but the live UI raises a **Save agent with errors? · (1 error)** confirmation dialog because Instructions are still empty at this point. | Added a NOTE explaining the expected dialog and that learners should click Save in the confirmation. |
| 6 | low | Code-block opening fence on line 319 (Description block) missing the blank line before it that the rest of the lab uses. | Inserted blank line. |
| 7 | low | Code-block opening fence on line 331 (Instructions block) missing the blank line before it. | Inserted blank line. |

## Files changed

- `_labs/core-concepts-variables-agents-channels.md` — 16 insertions, 8 deletions.

## Test plan

- [ ] Render `_labs/core-concepts-variables-agents-channels.md` (Jekyll preview or GitHub markdown view) and confirm:
  - [ ] UC1 *Open the Mailing List Topic* step 4 has a new NOTE about closing the Edit with Copilot panel.
  - [ ] UC1 *Review Existing Variables* step 1 includes the click-to-open-details-panel guidance + explains the misleading *Select a variable* card label.
  - [ ] UC1 *Review Existing Variables* step 2 reads **Save user response as** (with *user*).
  - [ ] UC2 *Create a Child Agent* step 5 has a blank line between *Input the following for the Description* and the opening fence.
  - [ ] UC2 *Create a Child Agent* step 6 has a NOTE about the expected *Save agent with errors? (1 error)* confirmation dialog.
  - [ ] UC2 *Configure Child Agent Instructions* step 1 has a blank line between the prose and the opening fence.
  - [ ] UC3 *Navigate to Channels* step 2 bullet list reads **Microsoft 365 and Microsoft Teams** / **Web app** / **Native app** / etc. instead of the old labels.

## Audit-coverage notes

- UC2 *Add Knowledge Sources to Child Agent* (the CAREful PDF upload) was not exercised — Playwright MCP file-chooser limitation, same as lab 2 UC2.
- **Slash-mention pattern verified working.** A prior audit caveat (PR #352) incorrectly claimed Playwright couldn't drive the `/` slash mention. This run confirmed it works: real DOM click into the Lexical contenteditable → `page.keyboard.press('/')` → popover renders with all tools / topics / agents / variables → click on the desired option inserts a real mention chip. See the comment on PR #352.
- UC3 *Deploy to Microsoft Teams and Microsoft 365 Copilot* (steps 12–22) was not exercised in this run. That flow requires a real publish + Teams web-app auth + Teams app install and is best validated as a separate dedicated pass.