### PR TITLE
mcs-alm: fix UI drift + UC2 numbering from interactive audit #357

### DIFF
--- a/_labs/mcs-alm.md
+++ b/_labs/mcs-alm.md
@@ -259,11 +259,11 @@ Create environment variables and connection references that enable your solution
 
 1. Open the solution you created in Use Case #1. If you didn't navigate away after the create it should leave you in the solution.
 
-1. Select **+ New**, then select **More** and choose **Environment variable**.
+1. Select **New**, then select **More** and choose **Environment variable**.
 
     ![Copilot Studio showing New menu expanded with Environment variable option highlighted](images/environment-variable-connection-reference.png)
 
-1. In **Name**, enter: `Custom Knowledge Endpoint`, then add your User Name to make it unique. We are only doing this because you will be deploying to a shared environment.
+1. In **Display name**, enter: `Custom Knowledge Endpoint`, then add your User Name to make it unique. We are only doing this because you will be deploying to a shared environment. The **Name** field below will auto-populate with a `cat_` prefixed schema name (e.g. `cat_CustomKnowledgeEndpointU2sypp5l9`) — leave that as-is.
 
 1. In **Data Type**, select **Text**.
 
@@ -280,7 +280,7 @@ Create environment variables and connection references that enable your solution
     > [!TIP]
     > Environment variables can also be of type **Secret** to retrieve secure values like API keys from Azure Key Vault at runtime.
 
-1. In the solution, select **+ New**, then select **More** and choose **Connection reference**.
+1. In the solution, select **New**, then select **More** and choose **Connection Reference**.
 
 1. Enter `ServiceNow` plus your User Name to make it unique , as the name. 
 

--- a/_labs/mcs-alm.md
+++ b/_labs/mcs-alm.md
@@ -171,9 +171,12 @@ Set up your development environment by creating a solution and custom publisher 
 
 #### Create a Solution
 
-1. In the left navigation (under the **...** menu), select **Solutions**.
+1. In the left navigation, select **Explore Power Platform** (the icon button at the bottom of the left nav). In the flyout menu that opens, choose **Solutions** under the **Explore** section.
 
     ![Copilot Studio navigation menu with Solutions option highlighted](images/solutions.png)
+
+    > [!NOTE]
+    > Selecting **Solutions** opens a new browser tab. Stay in the new tab for the rest of this use case — the original Copilot Studio Home tab is no longer needed. The Solutions surface itself is the Power Apps maker portal embedded in Copilot Studio.
 
 1. Select **New solution**.
 
@@ -190,7 +193,7 @@ Set up your development environment by creating a solution and custom publisher 
 
 #### Create a Publisher
 
-1. If you see a publisher with your User name you can select that one, otherwise select **+ New publisher** to create one.
+1. If you see a publisher with your User name you can select that one, otherwise select **New publisher** to create one.
 
 > [!TIP]
 > - Use the **username provided to you for logging into the lab** as the publisher name.
@@ -256,15 +259,15 @@ Create environment variables and connection references that enable your solution
 
 1. Open the solution you created in Use Case #1. If you didn't navigate away after the create it should leave you in the solution.
 
-2. Select **+ New**, then select **More** and choose **Environment variable**.
+1. Select **+ New**, then select **More** and choose **Environment variable**.
 
     ![Copilot Studio showing New menu expanded with Environment variable option highlighted](images/environment-variable-connection-reference.png)
 
-3. In **Name**, enter: `Custom Knowledge Endpoint`, then add your User Name to make it unique. We are only doing this because you will be deploying to a shared environment.
+1. In **Name**, enter: `Custom Knowledge Endpoint`, then add your User Name to make it unique. We are only doing this because you will be deploying to a shared environment.
 
-4. In **Data Type**, select **Text**.
+1. In **Data Type**, select **Text**.
 
-5. Leave **Default Value** blank, but under **Current Value**, select **+ New Value**, and enter the Custom Knowledge endpoint URL found in the [Lab Resources](https://copilotstudiotraining.sharepoint.com/sites/Workshop/SitePages/Lab-Assets.aspx).
+1. Leave **Default Value** blank, but under **Current Value**, select **+ New Value**, and enter the Custom Knowledge endpoint URL found in the [Lab Resources](https://copilotstudiotraining.sharepoint.com/sites/Workshop/SitePages/Lab-Assets.aspx).
 
     > [!IMPORTANT]
     > For configuration, use the provided values in the [**Lab Resources**](https://copilotstudiotraining.sharepoint.com/sites/Workshop/SitePages/Lab-Assets.aspx) (specific per training).
@@ -272,29 +275,29 @@ Create environment variables and connection references that enable your solution
     > [!TIP]
     > Notice how, under **Advanced**, you can set whether the current value can follow through with your solution deployment, or if it should be reset each time the solution is deployed to a new environment.
 
-6. Select **Save**.
+1. Select **Save**.
 
     > [!TIP]
     > Environment variables can also be of type **Secret** to retrieve secure values like API keys from Azure Key Vault at runtime.
 
-7. In the solution, select **+ New**, then select **More** and choose **Connection reference**.
+1. In the solution, select **+ New**, then select **More** and choose **Connection reference**.
 
-8. Enter `ServiceNow` plus your User Name to make it unique , as the name. 
+1. Enter `ServiceNow` plus your User Name to make it unique , as the name. 
 
     > [!TIP]
     > In other locales, the connector name may be localized.
 
-9. Select the connector **ServiceNow**.
+1. Select the connector **ServiceNow**.
 
-10. In the connection dropdown, choose **New connection** if none exists.
+1. In the connection dropdown, choose **New connection** if none exists.
 
-11. Log in through Power Apps in a new tab if needed, then return to Copilot Studio.
+1. Log in through Power Apps in a new tab if needed, then return to Copilot Studio.
 
     > [!IMPORTANT]
     > - For **ServiceNow** configuration values, use the provided values in the [**Lab Resources**](https://copilotstudiotraining.sharepoint.com/sites/Workshop/SitePages/Lab-Assets.aspx) (specific per training).
     > - For **ServiceNow**'s `Instance` configuration, be sure to scroll down in the connection screen.
 
-12. Above the **Connection** dropdown, select **Refresh** and choose the newly created connection.
+1. Above the **Connection** dropdown, select **Refresh** and choose the newly created connection.
 
 > [!TIP]
 > If the **Create** button is grayed out, it's because you pasted the display name. Type an extra character in the display name field and remove it to enable the button.


### PR DESCRIPTION
Closes #357.

## Summary

Applies the 4 findings from `mcs-lab-auditor` run `2026-05-25T1319Z-583e` which exercised **UC1 (Solutions + Publisher navigation and dialog)** against the live Copilot Studio UI. UC2 and UC3 were NOT exercised — they require event-issued Lab Resources / ServiceNow credentials / ALM Prod mutations.

## Findings → fixes

| # | Severity | Finding | Fix |
|---|---|---|---|
| 1 | medium | UC1 *Create a Solution* step 1 said *"In the left navigation (under the **...** menu), select **Solutions**"*. The current Copilot Studio left nav has no "..." menu — Solutions lives under the **Explore Power Platform** button at the bottom of the left nav (in a flyout that also lists Component collections + Power Platform shortcuts + AI integration links). | Reworded step 1 to "select **Explore Power Platform** (the icon button at the bottom of the left nav). In the flyout menu that opens, choose **Solutions** under the **Explore** section." The existing `images/solutions.png` reference was kept; ideally a maintainer should re-shoot the screenshot to show the new flyout. |
| 2 | low | Selecting **Solutions** opens a **new browser tab** that the lab doesn't mention. The Solutions surface inside that tab is also an iframe to `make.preview.powerapps.com` (the Power Apps maker portal embedded). | Added a `[!NOTE]` under step 1 telling learners to stay in the new tab and that Solutions is the Power Apps maker portal embedded. |
| 3 | low | UC1 *Create a Publisher* step 1 said *"+ New publisher"* — but the live UI button is **New publisher** (preceded by a small Plus icon glyph, not a literal "+" character). | Dropped the leading "+". |
| 4 | low | UC2 *Step-by-step instructions* (lines 257-300) used explicit `2.`, `3.`, ..., `12.` markers for its 12-step ordered list, breaking the repeated-`1.` convention used by UC1, UC3, and the rest of the repo. Surfaced by the static-phase background subagent. | Replaced every explicit marker with `1.`. No rendered-output change; source becomes consistent. |

## Files changed

- `_labs/mcs-alm.md` — 16 insertions, 13 deletions.

## Test plan

- [ ] Render `_labs/mcs-alm.md` (Jekyll preview or GitHub markdown view) and confirm:
  - [ ] UC1 *Create a Solution* step 1 reads about **Explore Power Platform** + Explore section + Solutions, and has the new-tab NOTE.
  - [ ] UC1 *Create a Publisher* step 1 reads **New publisher** (no leading "+").
  - [ ] UC2 step-by-step list renders the same 12 sequential numbers as before, but the source uses `1.` repeatedly.

## Audit-coverage notes

- **Positive observation** verified during the run: the **ALM Prod** environment IS visible in the env switcher for the workshop test account (`user.2sypp5l9@...`), so UC3 *Verify Your ALM Prod Environment* step 1 would pass.
- **UC2 not exercised**: requires the Custom Knowledge Endpoint URL + ServiceNow connection config from `copilotstudiotraining.sharepoint.com/sites/Workshop/SitePages/Lab-Assets.aspx` (returns 403 unauthenticated, as expected — these are per-event credentials).
- **UC3 not exercised beyond env verification**: deploying a real solution from DEV to a shared ALM Prod environment in an audit run would mutate shared tenant state. Best done as a dedicated audit pass with explicit user opt-in.
- A reviewer with access to the Lab Resources page can pick up UC2 + UC3 in a follow-up audit.

## Suggested follow-up

The `images/solutions.png` screenshot (line 176) was kept in place by this PR but no longer matches what the lab now describes ("Explore Power Platform" flyout instead of "..." menu). A maintainer with a clean lab account should re-shoot that screenshot.