### PR TITLE
fix(mcs-tools): add Greeting topic disable step before UC4 test

### DIFF
--- a/_labs/mcs-tools.md
+++ b/_labs/mcs-tools.md
@@ -855,6 +855,19 @@ Create a Chit Chat Agent with a custom prompt tool that controls response behavi
 
 1. Close the **Settings** menu using the **X** in the upper right corner.
 
+#### Turn Off the Default Greeting Topic
+
+1. Select the **Topics** tab in the top navigation.
+
+1. In the system topics list, select the **Greeting** topic.
+
+1. Select **More** in the top-right toolbar of the topic editor and turn off the topic (set the topic to **Off**).
+
+    > [!NOTE]
+    > The default **Greeting** topic fires on utterances classified as greetings ("Hello", "Hey", "Hi", etc.), and the orchestrator routes to it before it can route to a tool. Several of the test queries in the next step start with greeting-shaped phrases ("Hey do you like cats?"), so the Greeting topic would short-circuit the test if it remained enabled. Turning it off here lets the orchestrator route those queries through your Chit Chat Prompt tool.
+
+1. Confirm the banner reads "This topic has been turned off, and you won't be able to test it." then return to the **Overview** tab.
+
 #### Test Your Chit Chat Agent
 
 1. In the test pane, try the following chit chat queries:


### PR DESCRIPTION
Closes #361.

## Summary

- Adds a **Turn Off the Default Greeting Topic** sub-section between **Disable General Knowledge** and **Test Your Chit Chat Agent** in UC4 of \`_labs/mcs-tools.md\`.
- Includes a NOTE explaining why the toggle is needed: the orchestrator routes greeting-shaped utterances (\`Hey...\`) to the default Greeting topic before it can reach the Chit Chat Prompt tool, which would short-circuit the first test query.

## Why

The very first chit-chat test query in UC4 is "Hey do you like cats? I have a tabby." On a fresh workshop tenant the default **Greeting** topic intercepts that on the "Hey" trigger phrase and returns its canned greeting, so the Chit Chat Prompt tool never runs. The fix is a two-minute UI toggle but it's invisible to a first-time learner — they will incorrectly conclude their tool is broken.

Discovered during \`mcs-lab-auditor\` audit run \`2026-05-25T1545Z-7a2b\` on a fresh workshop tenant.

## Test plan

- [x] Verified the Greeting topic is enabled by default on a fresh agent.
- [x] Verified that with Greeting **enabled**, the first chit-chat query is intercepted by the Greeting topic and the Chit Chat Prompt tool does not fire.
- [x] Verified that with Greeting **disabled** via the Topics tab toggle, the orchestrator routes the same query to the Chit Chat Prompt tool.
- [ ] Re-run UC4 end-to-end following the updated lab text on a fresh workshop tenant to confirm all six test queries (3 chit-chat + 3 boundary) behave as the lab claims.