### PR TITLE
fix(mcs-governance): disambiguate SharePoint card + correct DLP block message

### DIFF
--- a/_labs/mcs-governance.md
+++ b/_labs/mcs-governance.md
@@ -229,7 +229,7 @@ Create a "Copilot Studio Advisor" agent in both the Green and Yellow zones, test
 
 1. Select **Add knowledge**.
 
-1. Select **SharePoint**.
+1. In the knowledge-source list, locate the **SharePoint** card marked **Powered by Work IQ** (further down the list — **not** the SharePoint shortcut inside the *Upload file* card at the top, which uploads files to Dataverse and waits on indexing). Select that card.
 
 1. Enter the following for the URL:
 
@@ -296,7 +296,7 @@ Create a "Copilot Studio Advisor" agent in both the Green and Yellow zones, test
 1. Notice that `learn.microsoft.com` shows a status of **Blocked**.
 
     > [!IMPORTANT]
-    > The status message will say something like _"Not allowed due to your organizational data loss prevention policies. Contact your admin."_ This is the DLP policy in action, blocking public website knowledge in the Green zone. Additionally, publishing your agent will also be blocked while DLP policies are being enforced on knowledge sources. You must remove the blocked knowledge source before you can publish.
+    > The status will read **Blocked**, and the agent-status warning panel will explain it with text similar to: _"Your organization's data loss prevention policies do not allow the creation of triggers. The 'shared_microsoftcopilotstudio' connector or one of its tools is blocked by the following policy: Bootcamp Green. Contact your admin with questions."_ (Exact wording may vary; the message names the connector and the specific DLP policy that blocked it.) This is the DLP policy in action, blocking public website knowledge in the Green zone. Additionally, publishing your agent will also be blocked while DLP policies are being enforced on knowledge sources. You must remove the blocked knowledge source before you can publish.
 
 ---
 


### PR DESCRIPTION
Closes #365.

## Summary

Two UC1 Part 1 (Green Zone) corrections in \`_labs/mcs-governance.md\`:

1. **"Select SharePoint" step** rewritten to point at the **SharePoint - Powered by Work IQ** card explicitly with a parenthetical disambiguating it from the Upload-to-Dataverse SharePoint shortcut inside the *Upload file* card. Same fix already applied to \`mcs-orchestration\` UC3 in #364.
2. **DLP block-message NOTE** updated to quote the actual message ("Your organization's data loss prevention policies do not allow the creation of triggers. The 'shared_microsoftcopilotstudio' connector or one of its tools is blocked by the following policy: Bootcamp Green. Contact your admin with questions.") and add a parenthetical allowing for minor variance, so future drift doesn't require re-editing.

## Why

- SharePoint ambiguity: the Add knowledge dialog has two SharePoint surfaces and the lab's "Select SharePoint" wording is non-specific. A learner can pick the Upload-to-Dataverse variant by accident and end up on the slow indexing path instead of the live Work IQ path the rest of UC1 implicitly assumes.
- Block-message wording: the live message is more verbose than the lab predicts and names the **specific DLP policy by name**. Learners matching the lab text verbatim against the live screen could conclude the wrong message is showing.

Discovered during \`mcs-lab-auditor\` audit run \`2026-05-26T0003Z-66c8\` on fresh Bootcamp Green / Yellow / Red environments. The progressive DLP zone model verified end-to-end across all three zones (Green blocks learn.microsoft.com; Yellow allows learn.microsoft.com but blocks microsoft.github.io; Red allows both).

## Test plan

- [x] Verified the SharePoint - Powered by Work IQ pick works in Green Zone: Implementation Guide pptx reaches Ready immediately (no Dataverse indexing wait).
- [x] Verified the actual block-message text on a fresh Bootcamp Green agent: matches the rewritten NOTE exactly.
- [x] Verified Yellow Zone (\`learn.microsoft.com\` Ready, \`microsoft.github.io/mcscatblog\` Blocked) and Red Zone (both Ready) behave per lab claims.
- [ ] Re-run UC1 end-to-end on a *brand-new* Bootcamp Green environment to confirm the SharePoint-pick wording lands the learner cleanly even when there's no prior knowledge entry on the agent.