### PR TITLE
autonomous-account-news: fix audit findings from #369

### DIFF
--- a/_labs/autonomous-account-news.md
+++ b/_labs/autonomous-account-news.md
@@ -147,9 +147,9 @@ Set up an autonomous agent with a recurring trigger that automatically activates
 
   1. Select **Agents** in the left navigation.
 
-  1. Select **Create agent from blank** in upper right corner.
+  1. Select **Create blank agent** in upper right corner.
 
-  1. Select **Edit** in the Details section and change  the Name to `Account News Assistant` and then select **Save**.
+  1. In the **Name your agent** dialog that opens, enter `Account News Assistant` in the **Enter agent name** textbox and select **Create**.
 
 #### Adding a Recurring Trigger
 
@@ -158,7 +158,7 @@ Set up an autonomous agent with a recurring trigger that automatically activates
   > [!TIP]
   > The triggers section may not be immediately available as it depends on background processes started when the agent is created.  This should take no more than a minute to complete.
 
-  1.  Select **Add a new Trigger** and select **Recurrence** and then select **Next**
+  1.  Select **Add trigger**, select **Recurrence**, and then select **Next**
 
   > [!TIP]
   > Please be aware that the triggers wizard can take a few moments to move between screens.
@@ -203,11 +203,11 @@ Set up an autonomous agent with a recurring trigger that automatically activates
 
 #### Step-by-step instructions
 
-1. Go to **Tools** in the top-level menu.
+1. Go to the agent's **Tools** tab (in the agent's top tab strip alongside Overview, Knowledge, Topics, etc.).
 
 1. Select **+ Add a tool**.
 
-1. Search and select `List rows from selected environment`.
+1. Search for `List rows` and select the **List rows from selected environment** action (under **Microsoft Dataverse**, displayed as *List rows from a table in a Power Platform environment*).
 
 1. Choose an existing Dataverse connection or add a new one (select Oauth as authentication type).
 
@@ -239,7 +239,7 @@ Set up an autonomous agent with a recurring trigger that automatically activates
       - **Value**: `Opportunities`
   
      Select **Add input** and select **Filter rows**.
-     - **Fill using**: `Set a custom value`.
+     - **Fill using**: `Custom value`.
      - **Value**: 
 
         ```
@@ -282,7 +282,7 @@ Set up an autonomous agent with a recurring trigger that automatically activates
 
 1. In the left menu, select **Generative AI**.
 
-1. Turn **On** the toggle for **Deep Reasoning**.
+1. Turn **On** the toggle for **Deep reasoning (preview)**.
 
     > [!TIP]
     > Deep reasoning is currently unavailable in the UI in certain regions.  If you do not see the Deep Reasoning toggle in the settings area, try accessing the agent via https://copilotstudio.preview.microsoft.com
@@ -669,7 +669,7 @@ Automate the final step: format relevant news into a clean, branded email for ac
 
 1. Now that your agent has a preloaded HTML template, configure an Outlook email tool to deliver the report.
 
-1. Go to **Tools** in the top-level menu.
+1. Go to the agent's **Tools** tab (in the agent's top tab strip alongside Overview, Knowledge, Topics, etc.).
 
 1. Select **+ Add a tool**.
 


### PR DESCRIPTION
Closes #369.

Apply the 7 corrections from `mcs-lab-auditor` run `2026-05-26T1052Z-bd1b` (6 markdown text fixes, plus a UC2/UC5 cross-reference disambiguation that touches the same phrase in two places). UC1-UC4 were exercised end-to-end in the live preview portal against a fresh DEV - User 2SYPP5L9 environment.

## What changed

- **UC1 line 150** — `Create agent from blank` → `Create blank agent` (current button label).
- **UC1 line 152** — Replace the obsolete `Edit in Details section → change Name → Save` flow with the current `Name your agent` modal dialog flow that fires immediately on Create blank agent. Also removes the double-space typo in the previous step.
- **UC1 line 161** — `Add a new Trigger` → `Add trigger`.
- **UC2 line 206 + UC5 line 672** — Disambiguate `Tools in the top-level menu` to `the agent's Tools tab` (Copilot Studio has both a global Tools page and a per-agent Tools tab; the autonomous flow needs the per-agent one).
- **UC2 line 210** — Clarify that the search-result card description (`List rows from a table in a Power Platform environment`) differs from the detail-panel title (`List rows from selected environment`).
- **UC2 line 242** — `Set a custom value` → `Custom value` (matches actual dropdown option; consistent with the same UC's earlier `Custom value` usage).
- **UC3 line 285** — `Deep Reasoning` → `Deep reasoning (preview)` (matches the current toggle label).

## What was deferred

UC5 (HTML report template via Power Fx formula editor with escaped-quote HTML + Outlook Send email (V2) tool + instruction step 6) was not exercised interactively because the Power Fx formula editor's rich-text behavior is fragile to automate. The agent's UC1-UC4 wiring (`Account News Assistant`, recurring trigger `Analyze Opportunities`, tool `Get Opportunity records` configured for the `Opportunities` table with the `cat_amount gt 300000 and cat_isclosed eq false` filter, Generative AI toggles, two custom topics + global variables, plus the 5-step instructions) is in place in the test tenant for a follow-up audit to start from UC5 step 1.

## Test plan

- [x] Verified all UI labels named in the corrections by snapshotting the live preview portal.
- [x] Verified the agent was created with the new modal-dialog flow.
- [x] Verified the Add trigger button label.
- [x] Verified the Dataverse action search/detail naming difference.
- [x] Verified Fill using dropdown contains only `Dynamically fill with AI` and `Custom value` options.
- [x] Verified the Generative AI toggle label is `Deep reasoning (preview)` (input id `CopilotStudiodeep-reasoning673`).
- [ ] Re-audit UC1-UC3 end-to-end on a brand-new workshop tenant to confirm the reworded steps land cleanly.
- [ ] Interactively exercise UC5 in a separate audit run to surface any additional drift in the HTML-template + Outlook-tool steps.