### PR TITLE
feat(issues): clean up labels, add module template, dynamic tracker menu

### DIFF
--- a/.github/ISSUE_TEMPLATE/bootcamp_feature.yml
+++ b/.github/ISSUE_TEMPLATE/bootcamp_feature.yml
@@ -1,6 +1,6 @@
 name: Bootcamp Feature
 description: Propose a change to the bootcamp itself — process, tooling, or how the bootcamp is managed
-labels: ["type: bootcamp-feature", "status: triage"]
+labels: ["type: bootcamp-feature", "status: triage", "bootcamp"]
 body:
   - type: dropdown
     id: area

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a problem with a lab
-labels: ["type: bug"]
+labels: ["type: bug", "status: triage", "lab"]
 body:
   - type: input
     id: lab

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,6 +1,6 @@
 name: Enhancement
 description: Suggest an improvement to an existing lab or to the site
-labels: ["type: lab-update"]
+labels: ["type: lab-update", "status: triage"]
 body:
   - type: dropdown
     id: lab

--- a/.github/ISSUE_TEMPLATE/new_lab.yml
+++ b/.github/ISSUE_TEMPLATE/new_lab.yml
@@ -1,6 +1,6 @@
 name: New Lab Proposal
 description: Propose a new lab for the collection
-labels: ["type: new-lab"]
+labels: ["type: new-lab", "status: triage"]
 body:
   - type: input
     id: title

--- a/.github/ISSUE_TEMPLATE/new_module.yml
+++ b/.github/ISSUE_TEMPLATE/new_module.yml
@@ -1,0 +1,77 @@
+name: New Module Proposal
+description: Propose a new module that introduces a concept — modules are delivered before labs and can include demos
+labels: ["type: new-module", "status: triage"]
+body:
+  - type: input
+    id: title
+    attributes:
+      label: Module title
+      description: A short, descriptive title for the module
+      placeholder: "e.g., Introduction to Generative Orchestration"
+    validations:
+      required: true
+  - type: textarea
+    id: concept
+    attributes:
+      label: What concept does this module introduce?
+      description: Describe the concept or topic this module will teach. What should the learner understand after completing it?
+    validations:
+      required: true
+  - type: dropdown
+    id: difficulty
+    attributes:
+      label: Difficulty
+      options:
+        - Beginner
+        - Intermediate
+        - Advanced
+    validations:
+      required: true
+  - type: textarea
+    id: demos
+    attributes:
+      label: Demos included
+      description: Will this module include demos? If so, briefly describe them. Demo content will be in the attached slide deck.
+      placeholder: |
+        - Demo 1: Show how to configure ...
+        - Demo 2: Walk through ...
+  - type: dropdown
+    id: has_lab
+    attributes:
+      label: Should a hands-on lab accompany this module?
+      description: Modules introduce concepts; labs let learners practice them. Select whether a lab should follow this module.
+      options:
+        - "Yes — a lab should be created for this module"
+        - "No — this module is concept-only for now"
+    validations:
+      required: true
+  - type: textarea
+    id: lab_description
+    attributes:
+      label: Lab outline (if applicable)
+      description: If a lab should accompany this module, briefly describe what the learner would build or practice
+      placeholder: "e.g., Build an autonomous agent that monitors account news and sends weekly summaries"
+  - type: textarea
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      description: What does the learner need to know or have before this module?
+      placeholder: |
+        - Familiarity with Copilot Studio basics
+        - Completed Module: Introduction to Agent Knowledge
+        - ...
+  - type: textarea
+    id: duration
+    attributes:
+      label: Estimated duration
+      description: How long should this module take to deliver (excluding lab time)?
+      placeholder: "e.g., 20 minutes, 45 minutes"
+  - type: textarea
+    id: deck
+    attributes:
+      label: Slide deck
+      description: >-
+        Drag and drop or paste the PowerPoint deck for this module. GitHub supports
+        files up to 25 MB. For larger files, upload to SharePoint or OneDrive and
+        paste the sharing link here instead.
+      placeholder: Drag and drop your slide deck here

--- a/.github/ISSUE_TEMPLATE/portal_enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/portal_enhancement.yml
@@ -1,6 +1,6 @@
 name: Portal Enhancements
 description: Report a bug, visual issue, or improvement suggestion for the labs site
-labels: ["portal-enhancement"]
+labels: ["type: portal-enhancement", "status: triage", "portal"]
 body:
   - type: dropdown
     id: type

--- a/assets/css/tracker.css
+++ b/assets/css/tracker.css
@@ -134,9 +134,13 @@
 }
 .tracker-oldest-cat.cat-bug { background: #d73a4a; }
 .tracker-oldest-cat.cat-newLab { background: #0e8a16; }
+.tracker-oldest-cat.cat-newModule { background: #a371f7; }
 .tracker-oldest-cat.cat-contentUpdate { background: #8957e5; }
 .tracker-oldest-cat.cat-portalEnhancement { background: #1d76db; }
 .tracker-oldest-cat.cat-bootcampFeature { background: #d4a72c; }
+.tracker-oldest-cat.cat-documentation { background: #0075ca; }
+.tracker-oldest-cat.cat-infrastructure { background: #7057ff; }
+.tracker-oldest-cat.cat-feature { background: #2da44e; }
 .tracker-oldest-title { flex: 1 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .tracker-oldest-age { color: var(--color-fg-muted); font-variant-numeric: tabular-nums; min-width: 40px; text-align: right; flex: 0 0 auto; }
 .tracker-oldest-age.old { color: #d73a4a; font-weight: 600; }
@@ -165,9 +169,13 @@
 }
 .tracker-card.cat-bug { border-left-color: #d73a4a; }
 .tracker-card.cat-newLab { border-left-color: #0e8a16; }
+.tracker-card.cat-newModule { border-left-color: #a371f7; }
 .tracker-card.cat-contentUpdate { border-left-color: #8957e5; }
 .tracker-card.cat-portalEnhancement { border-left-color: #1d76db; }
 .tracker-card.cat-bootcampFeature { border-left-color: #d4a72c; }
+.tracker-card.cat-documentation { border-left-color: #0075ca; }
+.tracker-card.cat-infrastructure { border-left-color: #7057ff; }
+.tracker-card.cat-feature { border-left-color: #2da44e; }
 .tracker-card-meta { font-size: 0.7em; color: var(--color-fg-muted); margin-top: 0.2em; }
 
 @media (max-width: 768px) {

--- a/assets/js/tracker/board.js
+++ b/assets/js/tracker/board.js
@@ -1,10 +1,7 @@
 const CAT_LABELS = {
-  bug: 'Bugs', newLab: 'New Labs', contentUpdate: 'Content',
+  bug: 'Bugs', newLab: 'New Labs', newModule: 'New Modules', contentUpdate: 'Content',
   portalEnhancement: 'Portal Enh', bootcampFeature: 'Bootcamp',
-};
-const CAT_TEMPLATE = {
-  bug: 'bug_report.yml', newLab: 'new_lab.yml', contentUpdate: 'enhancement.yml',
-  portalEnhancement: 'portal_enhancement.yml', bootcampFeature: 'bootcamp_feature.yml',
+  documentation: 'Docs', infrastructure: 'Infra', feature: 'Features',
 };
 const COLUMNS = [['triage', 'Triage'], ['backlog', 'Backlog'], ['inProgress', 'In Progress'], ['done', 'Done']];
 
@@ -32,9 +29,7 @@ function renderFilters(data) {
 }
 
 function smartUrl() {
-  const base = 'https://github.com/microsoft/mcs-labs/issues/new';
-  if (_state.activeCategory === 'all') return base + '/choose';
-  return `${base}?template=${CAT_TEMPLATE[_state.activeCategory]}`;
+  return 'https://github.com/microsoft/mcs-labs/issues/new/choose';
 }
 
 function renderKanban(data) {

--- a/assets/js/tracker/data.js
+++ b/assets/js/tracker/data.js
@@ -15,9 +15,13 @@ let _data = null;
 const LABEL_TO_CATEGORY = [
   ['type: bug', 'bug'],
   ['type: new-lab', 'newLab'],
+  ['type: new-module', 'newModule'],
   ['type: lab-update', 'contentUpdate'],
-  ['portal-enhancement', 'portalEnhancement'],
+  ['type: portal-enhancement', 'portalEnhancement'],
   ['type: bootcamp-feature', 'bootcampFeature'],
+  ['type: documentation', 'documentation'],
+  ['type: infrastructure', 'infrastructure'],
+  ['type: feature', 'feature'],
 ];
 
 const STATUS_LABELS = {
@@ -48,7 +52,7 @@ function deriveStatus(issue, windowDays = 90) {
 
 function shape(rawIssues) {
   const now = Date.now();
-  const cats = ['bug', 'newLab', 'contentUpdate', 'portalEnhancement', 'bootcampFeature'];
+  const cats = ['bug', 'newLab', 'newModule', 'contentUpdate', 'portalEnhancement', 'bootcampFeature', 'documentation', 'infrastructure', 'feature'];
   const categories = Object.fromEntries(cats.map(c => [c, { open: 0, triage: 0, backlog: 0, inProgress: 0, done30d: 0 }]));
 
   const issues = [];
@@ -179,4 +183,27 @@ export function isStale() {
 
 export function dataSource() {
   return _data?.source ?? 'unknown';
+}
+
+// Fetch issue templates from the GitHub API and populate the "+ New item" dropdown
+export async function loadTemplates() {
+  const el = document.querySelector('[data-tracker-templates]');
+  if (!el) return;
+  try {
+    const url = `https://api.github.com/repos/${REPO.owner}/${REPO.name}/contents/.github/ISSUE_TEMPLATE`;
+    const res = await fetch(url, { headers: { Accept: 'application/vnd.github+json' } });
+    if (!res.ok) throw new Error(`GitHub API ${res.status}`);
+    const files = await res.json();
+    const templates = files
+      .filter(f => f.name.endsWith('.yml') && f.name !== 'config.yml')
+      .map(f => {
+        const label = f.name.replace('.yml', '').replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+        return `<li><a href="https://github.com/${REPO.owner}/${REPO.name}/issues/new?template=${f.name}" target="_blank" rel="noopener">${label}</a></li>`;
+      });
+    el.innerHTML = templates.join('');
+  } catch (e) {
+    // Fallback: link to the template chooser page
+    console.warn('Tracker: failed to load issue templates', e);
+    el.innerHTML = `<li><a href="https://github.com/${REPO.owner}/${REPO.name}/issues/new/choose" target="_blank" rel="noopener">Create issue…</a></li>`;
+  }
 }

--- a/assets/js/tracker/insights.js
+++ b/assets/js/tracker/insights.js
@@ -1,10 +1,12 @@
 const CAT_COLORS = {
-  bug: '#d73a4a', newLab: '#0e8a16', contentUpdate: '#8957e5',
+  bug: '#d73a4a', newLab: '#0e8a16', newModule: '#a371f7', contentUpdate: '#8957e5',
   portalEnhancement: '#1d76db', bootcampFeature: '#d4a72c',
+  documentation: '#0075ca', infrastructure: '#7057ff', feature: '#2da44e',
 };
 const CAT_LABELS = {
-  bug: 'Bugs', newLab: 'New Labs', contentUpdate: 'Content',
+  bug: 'Bugs', newLab: 'New Labs', newModule: 'New Modules', contentUpdate: 'Content',
   portalEnhancement: 'Portal Enh', bootcampFeature: 'Bootcamp',
+  documentation: 'Docs', infrastructure: 'Infra', feature: 'Features',
 };
 
 export function render(data, { rangeDays }) {

--- a/assets/js/tracker/main.js
+++ b/assets/js/tracker/main.js
@@ -2,7 +2,7 @@
 layout: null
 permalink: /assets/js/tracker/main.js
 ---
-import { load, get, isStale, snapshotAgeMs, dataSource } from './data.js';
+import { load, get, isStale, snapshotAgeMs, dataSource, loadTemplates } from './data.js';
 import { render as renderInsights } from './insights.js';
 import { render as renderBoard } from './board.js';
 
@@ -30,6 +30,8 @@ async function init() {
   document.querySelectorAll('[data-tab]').forEach(btn => btn.addEventListener('click', () => switchTab(btn.getAttribute('data-tab'))));
 
   document.querySelector('[data-tracker-refresh]')?.addEventListener('click', refresh);
+
+  loadTemplates();
 
   // Re-tick the timestamp every 30s so it doesn't grow stale on the screen while the tab sits open.
   setInterval(updateTimestamp, 30000);

--- a/tracker.md
+++ b/tracker.md
@@ -46,11 +46,7 @@ header:
       <details class="tracker-newissue">
         <summary>+ New item</summary>
         <ul data-tracker-templates>
-          <li><a href="https://github.com/microsoft/mcs-labs/issues/new?template=bug_report.yml">Bug</a></li>
-          <li><a href="https://github.com/microsoft/mcs-labs/issues/new?template=new_lab.yml">New Lab</a></li>
-          <li><a href="https://github.com/microsoft/mcs-labs/issues/new?template=enhancement.yml">Content Update</a></li>
-          <li><a href="https://github.com/microsoft/mcs-labs/issues/new?template=portal_enhancement.yml">Portal Enhancement</a></li>
-          <li><a href="https://github.com/microsoft/mcs-labs/issues/new?template=bootcamp_feature.yml">Bootcamp Feature</a></li>
+          <li class="tracker-templates-loading">Loading…</li>
         </ul>
       </details>
     </div>


### PR DESCRIPTION
## Summary

Overhaul of issue tracking labels, templates, and the backlog tracker to ensure consistency and reduce maintenance burden.

### Label cleanup
- **Deleted 7 redundant/unused labels**: `bug`, `enhancement`, `documentation`, `invalid`, `question`, `wontfix`, `portal-enhancement`
- **Relabeled existing issues**: 45 `lab`-only issues now also carry `type: bug`; 4 portal issues moved to `type: portal-enhancement`
- **Added scope labels**: `module`, `portal`, `bootcamp` (alongside existing `lab`)
- **Completed severity scale**: added `severity:low` and `severity:high`

### New Module Proposal template
- Added `new_module.yml` — captures concept, difficulty, demos, whether a lab should follow, prerequisites, duration, and slide deck upload
- Auto-labels with `type: new-module` + `status: triage`

### Template consistency
- All 6 templates now consistently apply **type**, **status** (`status: triage`), and **scope** labels where applicable
- Fixed `portal_enhancement.yml` referencing deleted `portal-enhancement` label

### Tracker updates
- Added 4 new categories to tracker JS/CSS: `newModule`, `documentation`, `infrastructure`, `feature`
- **Replaced hardcoded '+ New item' dropdown** with dynamic fetch from GitHub API — no more stale menu when templates change
- Removed unused `CAT_TEMPLATE` mapping from board.js
- Added CSS card/badge colors for all new categories