### PR TITLE
fix(tracker): replace dynamic API menu with static Jekyll-rendered template list

### DIFF
--- a/_data/tracker.yml
+++ b/_data/tracker.yml
@@ -5,3 +5,19 @@ repo:
 
 snapshot:
   staleThresholdMs: 1800000 # 30 minutes — show "snapshot is N min old" indicator past this
+
+# Issue templates shown in the "+ New item" menu.
+# Keep in sync with .github/ISSUE_TEMPLATE/*.yml files.
+templates:
+  - label: "Bug Report"
+    file: "bug_report.yml"
+  - label: "New Lab Proposal"
+    file: "new_lab.yml"
+  - label: "New Module Proposal"
+    file: "new_module.yml"
+  - label: "Enhancement"
+    file: "enhancement.yml"
+  - label: "Portal Enhancement"
+    file: "portal_enhancement.yml"
+  - label: "Bootcamp Feature"
+    file: "bootcamp_feature.yml"

--- a/assets/js/tracker/data.js
+++ b/assets/js/tracker/data.js
@@ -184,26 +184,3 @@ export function isStale() {
 export function dataSource() {
   return _data?.source ?? 'unknown';
 }
-
-// Fetch issue templates from the GitHub API and populate the "+ New item" dropdown
-export async function loadTemplates() {
-  const el = document.querySelector('[data-tracker-templates]');
-  if (!el) return;
-  try {
-    const url = `https://api.github.com/repos/${REPO.owner}/${REPO.name}/contents/.github/ISSUE_TEMPLATE`;
-    const res = await fetch(url, { headers: { Accept: 'application/vnd.github+json' } });
-    if (!res.ok) throw new Error(`GitHub API ${res.status}`);
-    const files = await res.json();
-    const templates = files
-      .filter(f => f.name.endsWith('.yml') && f.name !== 'config.yml')
-      .map(f => {
-        const label = f.name.replace('.yml', '').replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-        return `<li><a href="https://github.com/${REPO.owner}/${REPO.name}/issues/new?template=${f.name}" target="_blank" rel="noopener">${label}</a></li>`;
-      });
-    el.innerHTML = templates.join('');
-  } catch (e) {
-    // Fallback: link to the template chooser page
-    console.warn('Tracker: failed to load issue templates', e);
-    el.innerHTML = `<li><a href="https://github.com/${REPO.owner}/${REPO.name}/issues/new/choose" target="_blank" rel="noopener">Create issue…</a></li>`;
-  }
-}

--- a/assets/js/tracker/main.js
+++ b/assets/js/tracker/main.js
@@ -2,7 +2,7 @@
 layout: null
 permalink: /assets/js/tracker/main.js
 ---
-import { load, get, isStale, snapshotAgeMs, dataSource, loadTemplates } from './data.js';
+import { load, get, isStale, snapshotAgeMs, dataSource } from './data.js';
 import { render as renderInsights } from './insights.js';
 import { render as renderBoard } from './board.js';
 
@@ -30,8 +30,6 @@ async function init() {
   document.querySelectorAll('[data-tab]').forEach(btn => btn.addEventListener('click', () => switchTab(btn.getAttribute('data-tab'))));
 
   document.querySelector('[data-tracker-refresh]')?.addEventListener('click', refresh);
-
-  loadTemplates();
 
   // Re-tick the timestamp every 30s so it doesn't grow stale on the screen while the tab sits open.
   setInterval(updateTimestamp, 30000);

--- a/tracker.md
+++ b/tracker.md
@@ -46,7 +46,9 @@ header:
       <details class="tracker-newissue">
         <summary>+ New item</summary>
         <ul data-tracker-templates>
-          <li class="tracker-templates-loading">Loading…</li>
+          {% for tpl in site.data.tracker.templates %}
+          <li><a href="https://github.com/{{ site.data.tracker.repo.owner }}/{{ site.data.tracker.repo.name }}/issues/new?template={{ tpl.file }}">{{ tpl.label }}</a></li>
+          {% endfor %}
         </ul>
       </details>
     </div>


### PR DESCRIPTION
## Summary

The '+ New item' dropdown in the backlog tracker was fetching templates from the GitHub API at runtime, which sent users to GitHub and broke the in-page experience.

### Changes
- **Removed** \loadTemplates()\ dynamic API fetch from \data.js\
- **Removed** \loadTemplates\ import and call from \main.js\
- **Added** \	emplates:\ list to \_data/tracker.yml\ as single source of truth
- **Updated** \	racker.md\ to render the menu statically via Jekyll \{% for %}\ loop

### How to maintain
When adding or removing issue templates in \.github/ISSUE_TEMPLATE/\, update the \	emplates:\ list in \_data/tracker.yml\ to keep the menu in sync.

### Follows up
PR #378 which introduced the dynamic fetch.