### PR TITLE
fix(tracker): remove duplicate '+ New item' link from board filter bar

### DIFF
--- a/assets/js/tracker/board.js
+++ b/assets/js/tracker/board.js
@@ -19,17 +19,12 @@ function renderFilters(data) {
   const el = document.querySelector('[data-tracker-filters]');
   el.innerHTML = `
     ${chips.map(([k, label, n]) => `<button class="tracker-chip ${k === _state.activeCategory ? 'is-active' : ''}" data-cat="${k}">${label} · ${n}</button>`).join('')}
-    <a class="tracker-chip tracker-newissue-smart" data-newissue-smart href="${smartUrl()}" target="_blank" rel="noopener">+ New item</a>
   `;
   el.querySelectorAll('[data-cat]').forEach(btn => btn.addEventListener('click', () => {
     _state.activeCategory = btn.getAttribute('data-cat');
     renderFilters(data);
     renderKanban(data);
   }));
-}
-
-function smartUrl() {
-  return 'https://github.com/microsoft/mcs-labs/issues/new/choose';
 }
 
 function renderKanban(data) {


### PR DESCRIPTION
## Summary

The board view had its own '+ New item' link in the filter chip bar that redirected users to GitHub's template chooser. Since the header already has the static '+ New item' dropdown (rendered from \_data/tracker.yml\), this duplicate link was redundant and distracting.

### Changes
- Removed the \+ New item\ anchor from \enderFilters()\ in \oard.js\
- Removed the unused \smartUrl()\ function

### Follows up
PR #378 (label cleanup) and PR #379 (static template menu)