### PR TITLE
Add Lab Doc Sync check: guard README ↔ _labs drift

### DIFF
--- a/.github/workflows/lab-doc-sync.yml
+++ b/.github/workflows/lab-doc-sync.yml
@@ -1,0 +1,26 @@
+name: Lab Doc Sync
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lab-doc-sync:
+    name: Lab Doc Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Check README ↔ _labs sync
+        run: |
+          git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD" | node scripts/check-lab-sync.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+- Added a `Lab Doc Sync` pull-request check (`scripts/check-lab-sync.js` + `.github/workflows/lab-doc-sync.yml`) that fails when `labs/<slug>/README.md` changes without the rendered `_labs/<slug>.md` — the file the site actually builds from. Prevents lab content updates from silently not appearing on the live portal.
 - The portal can now render from the consumed feed (feed-as-source-of-truth). `scripts/consume-feed.js` reads `_data/feed_subscriptions.yml` (self by default, optional external instances, `exclude` filters), merges (own wins), and materializes collection docs into a git-ignored `.feed-build/` that Jekyll renders via `_config.feed.yml` (`collections_dir`). Own content round-trips identically (verified gate); committed sources and the lab auditor are untouched.
 - **Content syndication feed (Phase 1, producer).** Build-time `scripts/build-feed.js` emits config-driven JSON feeds (`feed/<name>.json` + `feed/index.json`) of modules/events/workshops/labs with raw markdown, metadata, and absolute image URLs. Configured via `_data/feeds.yml`.
 - Content feed now publishes a scalable layout (schema 1.1): a lightweight per-feed `manifest.json` (no markdown) plus deduplicated per-item documents at `feed/items/<collection>/<slug>.json`, so consumers sync incrementally. The full inline `feed/<name>.json` bundle remains (toggle per feed via `bundle:` in `_data/feeds.yml`).

--- a/docs/CONTENT_FEED.md
+++ b/docs/CONTENT_FEED.md
@@ -153,3 +153,10 @@ and the self-feed round-trip gate.
 The full design and implementation notes live under
 [`docs/superpowers/`](./superpowers/) (`*-content-feed-design.md`,
 `*-feed-source-of-truth-design.md`, and the matching plans).
+
+## Lab content: README ↔ `_labs/`
+
+Each lab's content lives in two files: `labs/<slug>/README.md` (browsable on GitHub)
+and `_labs/<slug>.md` (the collection doc the **site renders from**). When you change a
+lab's `README.md`, you must update `_labs/<slug>.md` too, or the change won't appear on
+the live site. The **Lab Doc Sync** pull-request check enforces this.

--- a/docs/superpowers/plans/2026-06-17-lab-doc-sync-check.md
+++ b/docs/superpowers/plans/2026-06-17-lab-doc-sync-check.md
@@ -1,0 +1,380 @@
+# Lab Doc Sync Check Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `pull_request` CI check that fails when `labs/<slug>/README.md` changes without the rendered `_labs/<slug>.md` (the file the site builds from), preventing the "README updated but site not updated" bug (#420).
+
+**Architecture:** A pure function `findUnsyncedLabs(changedFiles, {readmeSlugs})` in `scripts/check-lab-sync.js` (unit-tested) plus a thin CLI that reads the PR's changed-file list from stdin and exits non-zero on violations. A small GitHub Actions workflow computes the changed files and runs the CLI.
+
+**Tech Stack:** Node 20+ (CommonJS, `node:test`), GitHub Actions. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-17-lab-doc-sync-check-design.md`
+
+## File Structure
+
+- **Create `scripts/check-lab-sync.js`** — pure `findUnsyncedLabs` + CLI. One responsibility: decide which labs have an out-of-sync README/`_labs` pair.
+- **Create `scripts/check-lab-sync.test.js`** — unit tests for the pure function + a CLI integration test.
+- **Create `.github/workflows/lab-doc-sync.yml`** — runs the check on pull requests.
+- **Modify `CHANGELOG.md`** and **`docs/CONTENT_FEED.md`** — document the README↔`_labs/` relationship and the check.
+
+---
+
+### Task 1: Scaffold `scripts/check-lab-sync.js`
+
+**Files:** Create `scripts/check-lab-sync.js`
+
+- [ ] **Step 1: Create the skeleton**
+
+```js
+'use strict';
+
+module.exports = {};
+
+// findUnsyncedLabs is added in the next task; the CLI entry is added last.
+```
+
+- [ ] **Step 2: Verify the existing suite still runs**
+
+Run: `npm test`
+Expected: PASS — existing tests still green; no new tests yet.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/check-lab-sync.js
+git commit -m "chore(lab-sync): scaffold lab-doc-sync check"
+```
+
+---
+
+### Task 2: `findUnsyncedLabs` pure function
+
+**Files:** Modify `scripts/check-lab-sync.js`; Test `scripts/check-lab-sync.test.js`
+
+- [ ] **Step 1: Write the failing tests (create the test file)**
+
+Create `scripts/check-lab-sync.test.js`:
+
+```js
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { findUnsyncedLabs } = require('./check-lab-sync');
+
+const slugs = (s) => new Set(s); // readmeSlugs helper
+
+test('README changed without _labs → violation', () => {
+  const r = findUnsyncedLabs(['labs/demo/README.md'], { readmeSlugs: slugs(['demo']) });
+  assert.deepEqual(r.violations, ['demo']);
+  assert.deepEqual(r.warnings, []);
+});
+
+test('README and _labs changed together → clean', () => {
+  const r = findUnsyncedLabs(['labs/demo/README.md', '_labs/demo.md'], { readmeSlugs: slugs(['demo']) });
+  assert.deepEqual(r.violations, []);
+  assert.deepEqual(r.warnings, []);
+});
+
+test('_labs changed without README (README exists) → warning, no violation', () => {
+  const r = findUnsyncedLabs(['_labs/demo.md'], { readmeSlugs: slugs(['demo']) });
+  assert.deepEqual(r.violations, []);
+  assert.deepEqual(r.warnings, ['demo']);
+});
+
+test('_labs changed for a README-less lab → clean (no warning)', () => {
+  const r = findUnsyncedLabs(['_labs/mcs-orchestration.md'], { readmeSlugs: slugs([]) });
+  assert.deepEqual(r.violations, []);
+  assert.deepEqual(r.warnings, []);
+});
+
+test('image-only change → clean', () => {
+  const r = findUnsyncedLabs(['labs/demo/images/x.png'], { readmeSlugs: slugs(['demo']) });
+  assert.deepEqual(r.violations, []);
+  assert.deepEqual(r.warnings, []);
+});
+
+test('new README added without _labs → violation', () => {
+  const r = findUnsyncedLabs(['labs/newlab/README.md'], { readmeSlugs: slugs(['newlab']) });
+  assert.deepEqual(r.violations, ['newlab']);
+});
+
+test('multiple labs evaluated independently', () => {
+  const r = findUnsyncedLabs(
+    ['labs/a/README.md', 'labs/b/README.md', '_labs/b.md', '_labs/c.md'],
+    { readmeSlugs: slugs(['a', 'b', 'c']) }
+  );
+  assert.deepEqual(r.violations, ['a']);   // a: README only
+  assert.deepEqual(r.warnings, ['c']);     // c: _labs only, README exists
+});
+
+test('unrelated files are ignored', () => {
+  const r = findUnsyncedLabs(['scripts/foo.js', 'README.md', '_data/x.yml'], { readmeSlugs: slugs(['demo']) });
+  assert.deepEqual(r.violations, []);
+  assert.deepEqual(r.warnings, []);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test scripts/check-lab-sync.test.js`
+Expected: FAIL — `findUnsyncedLabs is not a function`.
+
+- [ ] **Step 3: Implement `findUnsyncedLabs`**
+
+Append to `scripts/check-lab-sync.js`:
+
+```js
+const README_RE = /^labs\/([^/]+)\/README\.md$/;
+const LABS_RE = /^_labs\/([^/]+)\.md$/;
+
+function findUnsyncedLabs(changedFiles, { readmeSlugs } = {}) {
+  const readmes = readmeSlugs || new Set();
+  const changedReadmes = new Set();
+  const changedLabs = new Set();
+  for (const f of changedFiles) {
+    const r = String(f).match(README_RE);
+    if (r) { changedReadmes.add(r[1]); continue; }
+    const l = String(f).match(LABS_RE);
+    if (l) { changedLabs.add(l[1]); }
+  }
+  const violations = [];
+  for (const slug of changedReadmes) {
+    if (!changedLabs.has(slug)) violations.push(slug);
+  }
+  const warnings = [];
+  for (const slug of changedLabs) {
+    if (!changedReadmes.has(slug) && readmes.has(slug)) warnings.push(slug);
+  }
+  return { violations: violations.sort(), warnings: warnings.sort() };
+}
+module.exports.findUnsyncedLabs = findUnsyncedLabs;
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --test scripts/check-lab-sync.test.js`
+Expected: PASS — all 8 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-lab-sync.js scripts/check-lab-sync.test.js
+git commit -m "feat(lab-sync): findUnsyncedLabs pairing rule"
+```
+
+---
+
+### Task 3: CLI entry + integration test
+
+**Files:** Modify `scripts/check-lab-sync.js`; Test `scripts/check-lab-sync.test.js`
+
+- [ ] **Step 1: Write the failing integration tests (append)**
+
+These run the real CLI against the real `labs/` directory in the repo, feeding the changed-file list on stdin. `mcs-workflows` is an existing lab with both a README and a `_labs/` doc.
+
+```js
+const { execFileSync } = require('node:child_process');
+
+function runCli(changedFiles) {
+  try {
+    const stdout = execFileSync('node', ['scripts/check-lab-sync.js'], {
+      cwd: process.cwd(),
+      input: changedFiles.join('\n'),
+      encoding: 'utf8',
+    });
+    return { code: 0, stdout };
+  } catch (err) {
+    return { code: err.status, stdout: (err.stdout || '') + (err.stderr || '') };
+  }
+}
+
+test('CLI: README-only change for a real lab exits 1', () => {
+  const { code, stdout } = runCli(['labs/mcs-workflows/README.md']);
+  assert.equal(code, 1);
+  assert.match(stdout, /mcs-workflows/);
+  assert.match(stdout, /_labs\/mcs-workflows\.md was not/);
+});
+
+test('CLI: README + _labs changed together exits 0', () => {
+  const { code } = runCli(['labs/mcs-workflows/README.md', '_labs/mcs-workflows.md']);
+  assert.equal(code, 0);
+});
+
+test('CLI: empty input exits 0', () => {
+  const { code } = runCli([]);
+  assert.equal(code, 0);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `node --test scripts/check-lab-sync.test.js`
+Expected: FAIL — the CLI does nothing yet, so a README-only change exits 0 instead of 1.
+
+- [ ] **Step 3: Implement the CLI block**
+
+Append to the END of `scripts/check-lab-sync.js`:
+
+```js
+// CLI: read newline-separated changed files on stdin, exit 1 on violations.
+if (require.main === module) {
+  const fs = require('node:fs');
+  const path = require('node:path');
+
+  let input = '';
+  try { input = fs.readFileSync(0, 'utf8'); } catch { input = ''; }
+  const changedFiles = input.split('\n').map((s) => s.trim()).filter(Boolean);
+
+  const readmeSlugs = new Set();
+  try {
+    for (const slug of fs.readdirSync('labs')) {
+      if (fs.existsSync(path.join('labs', slug, 'README.md'))) readmeSlugs.add(slug);
+    }
+  } catch { /* no labs/ dir — leave empty */ }
+
+  const { violations, warnings } = findUnsyncedLabs(changedFiles, { readmeSlugs });
+
+  for (const slug of warnings) {
+    console.log(`::warning::⚠️ ${slug}: _labs/${slug}.md changed without labs/${slug}/README.md — the GitHub README may now be out of date.`);
+  }
+  if (violations.length) {
+    for (const slug of violations) {
+      console.error(`::error::❌ ${slug}: labs/${slug}/README.md changed but _labs/${slug}.md was not. The site renders from _labs/${slug}.md — update it so your change appears. (See docs/CONTENT_FEED.md.)`);
+    }
+    console.error(`\nlab-doc-sync: ${violations.length} lab(s) need their _labs/<slug>.md updated.`);
+    process.exit(1);
+  }
+  console.log(`lab-doc-sync: OK${warnings.length ? ` (${warnings.length} warning(s))` : ''}`);
+}
+```
+
+- [ ] **Step 4: Run the full suite to verify it passes**
+
+Run: `npm test`
+Expected: PASS — the CLI integration tests plus all earlier tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/check-lab-sync.js scripts/check-lab-sync.test.js
+git commit -m "feat(lab-sync): CLI reads changed files from stdin, fails on violations"
+```
+
+---
+
+### Task 4: Pull-request workflow
+
+**Files:** Create `.github/workflows/lab-doc-sync.yml`
+
+- [ ] **Step 1: Create the workflow**
+
+```yaml
+name: Lab Doc Sync
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  lab-doc-sync:
+    name: Lab Doc Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: "20"
+
+      - name: Check README ↔ _labs sync
+        run: |
+          git diff --name-only "${{ github.event.pull_request.base.sha }}...HEAD" | node scripts/check-lab-sync.js
+```
+
+> Using `pull_request.base.sha` (an ancestor guaranteed present with `fetch-depth: 0`)
+> rather than `origin/<base_ref>` (not always a local tracking ref after checkout).
+
+- [ ] **Step 2: Validate the workflow YAML and the diff command shape**
+
+Run:
+```
+node -e "const y=require('js-yaml'),fs=require('fs'); const d=y.load(fs.readFileSync('.github/workflows/lab-doc-sync.yml','utf8')); const on=d.on||d[true]; if(!('pull_request' in on)) throw new Error('no pull_request trigger'); const steps=d.jobs['lab-doc-sync'].steps.map(s=>s.name); console.log(steps.join(' -> ')); const run=d.jobs['lab-doc-sync'].steps.find(s=>s.name && s.name.includes('Check')).run; if(!/check-lab-sync\.js/.test(run)) throw new Error('does not run the check'); console.log('OK')"
+```
+Expected: prints the step list and `OK`.
+
+- [ ] **Step 3: Locally simulate the check against the current branch (sanity)**
+
+Run:
+```
+git diff --name-only origin/main...HEAD | node scripts/check-lab-sync.js
+```
+Expected: `lab-doc-sync: OK` (this branch changes only `scripts/`, `.github/`, and `docs/` — no lab README/`_labs` pairs — so there are no violations). Exit code 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/lab-doc-sync.yml
+git commit -m "ci(lab-sync): run README ↔ _labs check on pull requests"
+```
+
+---
+
+### Task 5: Documentation + final verification
+
+**Files:** Modify `CHANGELOG.md`, `docs/CONTENT_FEED.md`
+
+- [ ] **Step 1: Add a CHANGELOG entry**
+
+Add under the Unreleased/Added section in `CHANGELOG.md`:
+
+```markdown
+- Added a `Lab Doc Sync` pull-request check (`scripts/check-lab-sync.js` + `.github/workflows/lab-doc-sync.yml`) that fails when `labs/<slug>/README.md` changes without the rendered `_labs/<slug>.md` — the file the site actually builds from. Prevents lab content updates from silently not appearing on the live portal.
+```
+
+- [ ] **Step 2: Add a note to `docs/CONTENT_FEED.md`**
+
+Append a short section to `docs/CONTENT_FEED.md`:
+
+```markdown
+## Lab content: README ↔ `_labs/`
+
+Each lab's content lives in two files: `labs/<slug>/README.md` (browsable on GitHub)
+and `_labs/<slug>.md` (the collection doc the **site renders from**). When you change a
+lab's `README.md`, you must update `_labs/<slug>.md` too, or the change won't appear on
+the live site. The **Lab Doc Sync** pull-request check enforces this.
+```
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `npm test`
+Expected: PASS (all tests, including the new lab-sync tests).
+
+- [ ] **Step 4: Verify the check catches the real bug pattern**
+
+Run:
+```
+printf 'labs/mcs-workflows/README.md\n' | node scripts/check-lab-sync.js; echo "exit: $?"
+```
+Expected: prints the `::error::` for `mcs-workflows` and `exit: 1` — proving it would have caught PR #420.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md docs/CONTENT_FEED.md
+git commit -m "docs(lab-sync): document README ↔ _labs check"
+```
+
+---
+
+## Notes for the implementer
+
+- **Pure vs IO:** `findUnsyncedLabs` is pure (takes `readmeSlugs` as input) so it's fully unit-testable; the CLI block is the only part that reads stdin and the filesystem.
+- **`fs.readFileSync(0, 'utf8')`** reads stdin (fd 0). Empty stdin yields no changed files → exit 0.
+- **GitHub annotations:** `::error::`/`::warning::` lines surface inline on the PR. They also print as plain text locally, which the tests match on.
+- **Line endings:** the repo has `core.autocrlf=true` + `core.safecrlf=true`. If `git add`/`commit` errors with "LF would be replaced by CRLF", use `git -c core.safecrlf=false ...`.
+- **Test command:** `npm test` runs `node --test scripts/*.test.js`, which picks up `check-lab-sync.test.js` automatically.

--- a/docs/superpowers/specs/2026-06-17-lab-doc-sync-check-design.md
+++ b/docs/superpowers/specs/2026-06-17-lab-doc-sync-check-design.md
@@ -1,0 +1,109 @@
+# Lab Doc Sync Check — Design
+
+**Date:** 2026-06-17
+**Branch:** `dewain/lab-doc-sync-check`
+
+## Problem
+
+The site renders each lab from its **collection doc** `_labs/<slug>.md`, **not** from
+`labs/<slug>/README.md` (the README is excluded from the Jekyll build). The two are
+meant to hold the same content (README for GitHub browsing, `_labs/` for the site),
+but nothing keeps them in sync and there is no generator in the repo. So a PR that
+edits a README without updating `_labs/<slug>.md` ships content that **never appears on
+the live site** — exactly what happened with PR #420 (Use Case #2 was added to the
+mcs-workflows README but not to `_labs/mcs-workflows.md`, so it didn't render).
+
+## Why not auto-generate `_labs/` from READMEs
+
+A blanket "regenerate every `_labs/` from its README at build time" is **unsafe**.
+Measured across the 32 labs on `main`:
+
+- **17 in sync**, **12 drifted**, **3 have no README** (`mcs-orchestration`,
+  `agent-academy-recruit`, `copilot-studio-lite` — authored directly as `_labs/`).
+- Drift is **inconsistent in direction**: sometimes the README is newer
+  (`mcs-workflows`), sometimes `_labs/` has *more* content than the README
+  (`agent-builder-m365` — `_labs/` is ~21% longer).
+
+So there is no single source of truth. Auto-generating would **delete** the extra
+`_labs/` content on drifted labs and **break** the README-less labs. Reconciling all
+that is a separate, larger effort. This design instead adds a **guard** that prevents
+the bug going forward without touching existing content.
+
+## Decisions (locked)
+
+| Decision | Choice |
+| --- | --- |
+| Approach | A **CI co-edit guard** (PR check), not auto-generation |
+| Primary rule | **Hard fail** when a `labs/<slug>/README.md` changes but `_labs/<slug>.md` does not |
+| Reverse direction | **Soft warning** only when `_labs/<slug>.md` changes without its README (legitimate for drifted/README-less labs and metadata tweaks) |
+| Local helper | **Deferred** — a faithful README→`_labs/` generator is hard given the drift; the guard + a docs note is the starting point |
+| Existing drift | **Left alone** — the 12 drifted labs are not touched unless their README is edited in a future PR |
+
+## The rule
+
+Given the set of files changed in a PR (vs the base branch) and the set of slugs that
+have a `labs/<slug>/README.md` in the repo:
+
+- **Violation (hard fail):** `labs/<slug>/README.md` is in the changed set **and**
+  `_labs/<slug>.md` is **not**. (Covers edits *and* newly added READMEs.)
+- **Warning (non-blocking):** `_labs/<slug>.md` is in the changed set, its README
+  exists in the repo, but `labs/<slug>/README.md` is **not** in the changed set.
+- **Ignored:** anything other than `labs/<slug>/README.md` and `_labs/<slug>.md`
+  (e.g. `labs/<slug>/images/**`), and any lab with no README (never violates).
+
+A slug is paired by filename: `labs/<slug>/README.md` ↔ `_labs/<slug>.md`.
+
+## Components
+
+### `scripts/check-lab-sync.js`
+
+- **Pure function** `findUnsyncedLabs(changedFiles, { readmeSlugs })` →
+  `{ violations: string[], warnings: string[] }` (slugs). No filesystem/network — fully
+  unit-testable. `readmeSlugs` is the set of slugs that have a README in the repo
+  (passed in so the function stays pure).
+- **CLI** (`require.main`): reads the changed-file list (newline-separated on stdin),
+  computes `readmeSlugs` from the filesystem (`labs/*/README.md`), calls the pure
+  function, prints a clear report, and exits **1** if there are violations (warnings
+  print but do not fail).
+
+CommonJS + `node:test`, matching the repo's existing `scripts/*.js` convention.
+
+### `.github/workflows/lab-doc-sync.yml`
+
+- Trigger: `pull_request` (all branches).
+- Steps: `actions/checkout` with `fetch-depth: 0`; compute changed files with
+  `git diff --name-only origin/${{ github.base_ref }}...HEAD`; pipe to
+  `node scripts/check-lab-sync.js`. The job fails iff the script exits non-zero.
+
+## Messages
+
+- **Violation:**
+  `❌ <slug>: labs/<slug>/README.md changed but _labs/<slug>.md was not. The site renders from _labs/<slug>.md — update it so your change appears. (See docs/CONTENT_FEED.md / the README↔_labs note.)`
+- **Warning:**
+  `⚠️ <slug>: _labs/<slug>.md changed without labs/<slug>/README.md — the GitHub README may now be out of date.`
+
+## Testing
+
+Unit tests for `findUnsyncedLabs` (`scripts/check-lab-sync.test.js`):
+
+- README-only change → violation.
+- README + `_labs/` changed together → clean.
+- `_labs/`-only change, README exists → warning, no violation.
+- `_labs/`-only change, README-less lab → clean (no warning).
+- Image-only change (`labs/<slug>/images/x.png`) → clean.
+- New lab (README added, `_labs/` added) → clean; README added without `_labs/` → violation.
+- Multiple labs in one PR → each evaluated independently.
+- Unrelated files (e.g. `scripts/foo.js`) → ignored.
+
+## Out of scope
+
+- Auto-generating or reconciling `_labs/` content (the drift).
+- A `generate-labs` author helper (deferred).
+- Enforcing README parity as a hard failure (kept as a soft warning).
+
+## Documentation
+
+A short note (in `CHANGELOG.md`, and a line in `docs/CONTENT_FEED.md` or the
+contributing docs) that lab content lives in **both** `labs/<slug>/README.md` (GitHub)
+and `_labs/<slug>.md` (the rendered site), and that the PR check enforces updating the
+latter when the former changes.

--- a/scripts/check-lab-sync.js
+++ b/scripts/check-lab-sync.js
@@ -2,8 +2,6 @@
 
 module.exports = {};
 
-// findUnsyncedLabs is added in the next task; the CLI entry is added last.
-
 const README_RE = /^labs\/([^/]+)\/README\.md$/;
 const LABS_RE = /^_labs\/([^/]+)\.md$/;
 

--- a/scripts/check-lab-sync.js
+++ b/scripts/check-lab-sync.js
@@ -3,3 +3,28 @@
 module.exports = {};
 
 // findUnsyncedLabs is added in the next task; the CLI entry is added last.
+
+const README_RE = /^labs\/([^/]+)\/README\.md$/;
+const LABS_RE = /^_labs\/([^/]+)\.md$/;
+
+function findUnsyncedLabs(changedFiles, { readmeSlugs } = {}) {
+  const readmes = readmeSlugs || new Set();
+  const changedReadmes = new Set();
+  const changedLabs = new Set();
+  for (const f of changedFiles) {
+    const r = String(f).match(README_RE);
+    if (r) { changedReadmes.add(r[1]); continue; }
+    const l = String(f).match(LABS_RE);
+    if (l) { changedLabs.add(l[1]); }
+  }
+  const violations = [];
+  for (const slug of changedReadmes) {
+    if (!changedLabs.has(slug)) violations.push(slug);
+  }
+  const warnings = [];
+  for (const slug of changedLabs) {
+    if (!changedReadmes.has(slug) && readmes.has(slug)) warnings.push(slug);
+  }
+  return { violations: violations.sort(), warnings: warnings.sort() };
+}
+module.exports.findUnsyncedLabs = findUnsyncedLabs;

--- a/scripts/check-lab-sync.js
+++ b/scripts/check-lab-sync.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {};
+
+// findUnsyncedLabs is added in the next task; the CLI entry is added last.

--- a/scripts/check-lab-sync.js
+++ b/scripts/check-lab-sync.js
@@ -28,3 +28,34 @@ function findUnsyncedLabs(changedFiles, { readmeSlugs } = {}) {
   return { violations: violations.sort(), warnings: warnings.sort() };
 }
 module.exports.findUnsyncedLabs = findUnsyncedLabs;
+
+// CLI: read newline-separated changed files on stdin, exit 1 on violations.
+if (require.main === module) {
+  const fs = require('node:fs');
+  const path = require('node:path');
+
+  let input = '';
+  try { input = fs.readFileSync(0, 'utf8'); } catch { input = ''; }
+  const changedFiles = input.split('\n').map((s) => s.trim()).filter(Boolean);
+
+  const readmeSlugs = new Set();
+  try {
+    for (const slug of fs.readdirSync('labs')) {
+      if (fs.existsSync(path.join('labs', slug, 'README.md'))) readmeSlugs.add(slug);
+    }
+  } catch { /* no labs/ dir — leave empty */ }
+
+  const { violations, warnings } = findUnsyncedLabs(changedFiles, { readmeSlugs });
+
+  for (const slug of warnings) {
+    console.log(`::warning::⚠️ ${slug}: _labs/${slug}.md changed without labs/${slug}/README.md — the GitHub README may now be out of date.`);
+  }
+  if (violations.length) {
+    for (const slug of violations) {
+      console.error(`::error::❌ ${slug}: labs/${slug}/README.md changed but _labs/${slug}.md was not. The site renders from _labs/${slug}.md — update it so your change appears. (See docs/CONTENT_FEED.md.)`);
+    }
+    console.error(`\nlab-doc-sync: ${violations.length} lab(s) need their _labs/<slug>.md updated.`);
+    process.exit(1);
+  }
+  console.log(`lab-doc-sync: OK${warnings.length ? ` (${warnings.length} warning(s))` : ''}`);
+}

--- a/scripts/check-lab-sync.test.js
+++ b/scripts/check-lab-sync.test.js
@@ -34,8 +34,8 @@ test('image-only change → clean', () => {
   assert.deepEqual(r.warnings, []);
 });
 
-test('new README added without _labs → violation', () => {
-  const r = findUnsyncedLabs(['labs/newlab/README.md'], { readmeSlugs: slugs(['newlab']) });
+test('new README added without _labs → violation (slug not yet on disk)', () => {
+  const r = findUnsyncedLabs(['labs/newlab/README.md'], { readmeSlugs: slugs([]) });
   assert.deepEqual(r.violations, ['newlab']);
 });
 

--- a/scripts/check-lab-sync.test.js
+++ b/scripts/check-lab-sync.test.js
@@ -1,0 +1,55 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { findUnsyncedLabs } = require('./check-lab-sync');
+
+const slugs = (s) => new Set(s); // readmeSlugs helper
+
+test('README changed without _labs → violation', () => {
+  const r = findUnsyncedLabs(['labs/demo/README.md'], { readmeSlugs: slugs(['demo']) });
+  assert.deepEqual(r.violations, ['demo']);
+  assert.deepEqual(r.warnings, []);
+});
+
+test('README and _labs changed together → clean', () => {
+  const r = findUnsyncedLabs(['labs/demo/README.md', '_labs/demo.md'], { readmeSlugs: slugs(['demo']) });
+  assert.deepEqual(r.violations, []);
+  assert.deepEqual(r.warnings, []);
+});
+
+test('_labs changed without README (README exists) → warning, no violation', () => {
+  const r = findUnsyncedLabs(['_labs/demo.md'], { readmeSlugs: slugs(['demo']) });
+  assert.deepEqual(r.violations, []);
+  assert.deepEqual(r.warnings, ['demo']);
+});
+
+test('_labs changed for a README-less lab → clean (no warning)', () => {
+  const r = findUnsyncedLabs(['_labs/mcs-orchestration.md'], { readmeSlugs: slugs([]) });
+  assert.deepEqual(r.violations, []);
+  assert.deepEqual(r.warnings, []);
+});
+
+test('image-only change → clean', () => {
+  const r = findUnsyncedLabs(['labs/demo/images/x.png'], { readmeSlugs: slugs(['demo']) });
+  assert.deepEqual(r.violations, []);
+  assert.deepEqual(r.warnings, []);
+});
+
+test('new README added without _labs → violation', () => {
+  const r = findUnsyncedLabs(['labs/newlab/README.md'], { readmeSlugs: slugs(['newlab']) });
+  assert.deepEqual(r.violations, ['newlab']);
+});
+
+test('multiple labs evaluated independently', () => {
+  const r = findUnsyncedLabs(
+    ['labs/a/README.md', 'labs/b/README.md', '_labs/b.md', '_labs/c.md'],
+    { readmeSlugs: slugs(['a', 'b', 'c']) }
+  );
+  assert.deepEqual(r.violations, ['a']);   // a: README only
+  assert.deepEqual(r.warnings, ['c']);     // c: _labs only, README exists
+});
+
+test('unrelated files are ignored', () => {
+  const r = findUnsyncedLabs(['scripts/foo.js', 'README.md', '_data/x.yml'], { readmeSlugs: slugs(['demo']) });
+  assert.deepEqual(r.violations, []);
+  assert.deepEqual(r.warnings, []);
+});

--- a/scripts/check-lab-sync.test.js
+++ b/scripts/check-lab-sync.test.js
@@ -53,3 +53,35 @@ test('unrelated files are ignored', () => {
   assert.deepEqual(r.violations, []);
   assert.deepEqual(r.warnings, []);
 });
+
+const { execFileSync } = require('node:child_process');
+
+function runCli(changedFiles) {
+  try {
+    const stdout = execFileSync('node', ['scripts/check-lab-sync.js'], {
+      cwd: process.cwd(),
+      input: changedFiles.join('\n'),
+      encoding: 'utf8',
+    });
+    return { code: 0, stdout };
+  } catch (err) {
+    return { code: err.status, stdout: (err.stdout || '') + (err.stderr || '') };
+  }
+}
+
+test('CLI: README-only change for a real lab exits 1', () => {
+  const { code, stdout } = runCli(['labs/mcs-workflows/README.md']);
+  assert.equal(code, 1);
+  assert.match(stdout, /mcs-workflows/);
+  assert.match(stdout, /_labs\/mcs-workflows\.md was not/);
+});
+
+test('CLI: README + _labs changed together exits 0', () => {
+  const { code } = runCli(['labs/mcs-workflows/README.md', '_labs/mcs-workflows.md']);
+  assert.equal(code, 0);
+});
+
+test('CLI: empty input exits 0', () => {
+  const { code } = runCli([]);
+  assert.equal(code, 0);
+});


### PR DESCRIPTION
## Summary

Adds a `pull_request` check that **fails when `labs/<slug>/README.md` changes without the rendered `_labs/<slug>.md`** — the file the site actually builds from. This prevents the class of bug where #420's *Use Case #2* was added to the mcs-workflows README but didn't appear on the live site (the README is excluded from the Jekyll build).

- **`scripts/check-lab-sync.js`** — pure `findUnsyncedLabs(changedFiles, {readmeSlugs})` → `{violations, warnings}`, plus a CLI that reads the PR's changed files from stdin, emits `::error::`/`::warning::` annotations, and exits 1 on violations.
- **`.github/workflows/lab-doc-sync.yml`** — runs on `pull_request`, diffing against the PR base SHA.
- **Co-edit guard, not auto-generation.** The labs have drifted inconsistently (17 in-sync, 12 drifted, 3 README-less), so regenerating `_labs/` from READMEs is unsafe. Reverse direction (`_labs/` changed without README) is a non-blocking warning; existing drift is left untouched.
- **Docs:** CHANGELOG entry + a README↔`_labs/` section in `docs/CONTENT_FEED.md`.

## Test Plan

- [x] `npm test` — 65 pass (11 new: 8 unit for the pairing rule + 3 CLI integration against the real `labs/`)
- [x] Verified it catches the #420 pattern: a README-only change exits 1 with an actionable message
- [ ] CI: this check runs on this PR (and passes, since the PR touches no lab README/`_labs` pair)

Design + plan: `docs/superpowers/specs/2026-06-17-lab-doc-sync-check-design.md`, `docs/superpowers/plans/2026-06-17-lab-doc-sync-check.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)