### PR TITLE
Adjust tools module (30m) & workflows lab (60m) durations + agendas

### DIFF
--- a/_data/agendas/advanced-agent-in-a-day.yml
+++ b/_data/agendas/advanced-agent-in-a-day.yml
@@ -82,4 +82,4 @@ schedule:
   - type: module
     slug: copilot-studio-plugin
     label: "Module 5"
-    time: "15:45"
+    time: "16:00"

--- a/_data/agendas/bootcamp.yml
+++ b/_data/agendas/bootcamp.yml
@@ -150,30 +150,30 @@ schedule:
     label: "Module 8"
     title: "Tools"
     time: "13:00"
-    duration: 45
+    duration: 30
 
   - type: lab
     slug: mcs-tools
     label: "Lab 7"
     title: "Tools"
-    time: "13:45"
+    time: "13:30"
 
   - type: module
     slug: orchestration
     label: "Module 9"
     title: "Orchestration and Dynamic Chaining Concepts w/ Demos"
-    time: "14:45"
+    time: "14:30"
     duration: 45
 
   - type: lab
     slug: mcs-orchestration
     label: "Lab 8"
     title: "Orchestration with Copilot Studio"
-    time: "15:30"
+    time: "15:15"
 
   - type: break
     title: "Networking time"
-    time: "16:30"
+    time: "16:15"
     duration: 60
 
   # --- Day 3 ------------------------------------------------------------

--- a/_labs/mcs-workflows.md
+++ b/_labs/mcs-workflows.md
@@ -3,7 +3,7 @@ layout: lab
 module: workflows
 title: "Workflows"
 order: 340
-duration: 45
+duration: 60
 difficulty: 300
 lab_type: local
 section: advanced_labs
@@ -24,7 +24,7 @@ Build an **autonomous agent** in Microsoft Copilot Studio using **Workflows** �
 
 | Level | Persona | Duration | Purpose |
 | ----- | ------- | -------- | ------- |
-| 300 | Maker | 45 minutes | After completing this lab, participants will be able to create a Workflow in Copilot Studio, fire it from an event-driven **trigger**, and embed a non-deterministic **inline agent** that reasons over the trigger's data and acts through tools (Outlook calendar, Microsoft To Do, and web search) — going beyond the classic, deterministic autonomous-agent model. |
+| 300 | Maker | 60 minutes | After completing this lab, participants will be able to create a Workflow in Copilot Studio, fire it from an event-driven **trigger**, and embed a non-deterministic **inline agent** that reasons over the trigger's data and acts through tools (Outlook calendar, Microsoft To Do, and web search) — going beyond the classic, deterministic autonomous-agent model. |
 
 ---
 
@@ -62,7 +62,7 @@ Think of Workflows as the autonomous side of Copilot Studio:
 - "My flows are rigid — I need a step that can reason about messy, real-world inputs and choose what to do."
 - "I want an agent that can read my calendar, book time, and update a task — on its own."
 
-**In 45 minutes, you'll build an autonomous Workflow whose inline agent schedules focus time on your calendar and enriches a to-do — triggered automatically by simply creating a task.**
+**In 60 minutes, you'll build an autonomous Workflow whose inline agent schedules focus time on your calendar and enriches a to-do — triggered automatically by simply creating a task.**
 
 ---
 

--- a/_modules/tools-overview.md
+++ b/_modules/tools-overview.md
@@ -2,7 +2,7 @@
 layout: module
 title: "Copilot Studio Tools"
 order: 1080
-duration: 45
+duration: 30
 difficulty: 300
 section: intermediate_modules
 description: "Connectors, Power Automate flows, and custom tools in Copilot Studio."

--- a/labs/mcs-workflows/README.md
+++ b/labs/mcs-workflows/README.md
@@ -8,7 +8,7 @@ Build an **autonomous agent** in Microsoft Copilot Studio using **Workflows** �
 
 | Level | Persona | Duration | Purpose |
 | ----- | ------- | -------- | ------- |
-| 300 | Maker | 45 minutes | After completing this lab, participants will be able to create a Workflow in Copilot Studio, fire it from an event-driven **trigger**, and embed a non-deterministic **inline agent** that reasons over the trigger's data and acts through tools (Outlook calendar, Microsoft To Do, and web search) — going beyond the classic, deterministic autonomous-agent model. |
+| 300 | Maker | 60 minutes | After completing this lab, participants will be able to create a Workflow in Copilot Studio, fire it from an event-driven **trigger**, and embed a non-deterministic **inline agent** that reasons over the trigger's data and acts through tools (Outlook calendar, Microsoft To Do, and web search) — going beyond the classic, deterministic autonomous-agent model. |
 
 ---
 
@@ -46,7 +46,7 @@ Think of Workflows as the autonomous side of Copilot Studio:
 - "My flows are rigid — I need a step that can reason about messy, real-world inputs and choose what to do."
 - "I want an agent that can read my calendar, book time, and update a task — on its own."
 
-**In 45 minutes, you'll build an autonomous Workflow whose inline agent schedules focus time on your calendar and enriches a to-do — triggered automatically by simply creating a task.**
+**In 60 minutes, you'll build an autonomous Workflow whose inline agent schedules focus time on your calendar and enriches a to-do — triggered automatically by simply creating a task.**
 
 ---
 


### PR DESCRIPTION
## Summary

Adjust presentation/lab times and reflect them in the event/workshop agendas.

- **Tools module** (`_modules/tools-overview.md`): 45 → **30 min**
- **Workflows lab** (`_labs/mcs-workflows.md` + `labs/mcs-workflows/README.md`): 45 → **60 min** (front matter + Lab Details table + intro line; README and `_labs` co-edited per the Lab Doc Sync guard)
- **Tools lab**: already 60 min — no change

**Agendas (only the two that include these items):**
- `bootcamp.yml` (Day 2): `tools-overview` 45 → 30, then the rest of Day 2 cascades −15m (`mcs-tools 13:30`, `orchestration 14:30`, `mcs-orchestration 15:15`, `Networking 16:15`).
- `advanced-agent-in-a-day.yml`: the workflows lab now occupies 60m → `copilot-studio-plugin` shifts `15:45 → 16:00`.
- `agent-in-a-day.yml` / `mcs-in-a-day.yml`: unchanged (they don't include these items).

## Verification
- Both agendas parse; the schedules remain consistent (no overlaps).
- `Lab Doc Sync` passes (workflows README + `_labs` co-edited).

> Note: the "Use Cases Covered" table in the workflows lab still lists only UC#1's per-use-case effort and the Advanced Agent hero "6 Labs" count look stale — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)