### PR TITLE
mcs-governance: fix audit findings from #440

### DIFF
--- a/_labs/mcs-governance.md
+++ b/_labs/mcs-governance.md
@@ -182,45 +182,32 @@ Create a "Copilot Studio Advisor" agent in both the Green and Yellow zones, test
 
 #### Create the Agent
 
-1. Select **Home** in the left navigation to return to the main page.
+1. In the left navigation, select **Agents**.
 
-1. In the **"What would you like to build?"** pane, find the text area that says _"Start building by describing what your agent needs to do"_.
+1. On the Agents list, select the **down-arrow (chevron)** next to **New Agent**, then choose **New classic agent**.
 
-1. Enter the following text into the description field, but do not send it yet you will be adding more in the next step:
+    > [!NOTE]
+    > Keep the **New experience** toggle **ON**. **New classic agent** opens the classic canvas in a new browser tab without switching your experience. The first time you do this you may see a one-time **Welcome to Microsoft Copilot Studio** dialog — select **Get Started**. If that dialog is stacked behind the **Name your agent** dialog, select **Cancel**, complete **Get Started**, then retry **New classic agent**.
 
-    ```text
-    Help me build an agent that knows everything about building agents in Power Platform Copilot Studio. You're an expert, you're a coach, you give proactive advice on how to build Copilot Studio agents. And your knowledge is built on top of a SharePoint document.
-    ```
-
-1. After typing the description, add the following **SharePoint link** to the end of the instructions
-
-    ```
-    Here is the document to use as knowledge: https://copilotstudiotraining.sharepoint.com/:p:/s/Workshop/IQDYEPT5O76JR5akoXWdwO-PAR3IVlIBJ-RqZqpHy2cCRLs?e=qpIVD6
-    ```
-
-1. At the end of your instructions, add the following text:
+1. In the **Name your agent** dialog, enter the following and select **Create**:
 
     ```text
-    Please name this agent Copilot Studio Advisor [YourUsername]
+    Copilot Studio Advisor [YourUsername]
     ```
 
     > [!NOTE]
     > We add the username so we can find your agent easily in this shared environment.
 
-1. Before selecting the blue arrow to create, select the **Settings** wheel icon in the bottom-left corner.
-
-1. In the Settings pane, select the **Solution** you created earlier in this lab (named with your username).
-
-1. Optionally, give your agent a custom **Schema Name**.
+1. After the classic agent canvas opens, select **Settings** (gear icon) and confirm the agent is saved into the **Solution** you created earlier in this lab (named with your username). Optionally, give your agent a custom **Schema Name**.
 
     > [!TIP]
     > Schema names are used for advanced management of your agents. We advise using schema names in collaboration with the description. For example: `mcs_build_advisor_[YourUsername]_green`. Include the zone name (green, yellow, red) so you can tell them apart later.
 
-1. Select the **blue arrow** on the right side to submit and create your agent.
+1. A **New classic agent** is created blank — empty Instructions, default system topics, and the model defaults to Claude Sonnet 4.6. In the **Instructions** section, select **Edit**, paste the following, and save:
 
-1. Wait for Copilot Studio to build your agent. It will generate your name, description, and auto-generated instructions.
-
-1. Scroll down and notice that Copilot Studio has added suggested knowledge sources such as training hands-on labs, PowerPoint decks, and other capabilities.
+    ```text
+    You are an expert coach for building agents in Power Platform Copilot Studio. You give proactive, practical advice on how to design, build, and govern Copilot Studio agents. Ground every answer in the SharePoint Implementation Guide that has been added as knowledge, and cite it when you can. If a question cannot be answered from that knowledge, say so plainly rather than guessing.
+    ```
 
 #### Add SharePoint Knowledge
 
@@ -329,30 +316,26 @@ Create a "Copilot Studio Advisor" agent in both the Green and Yellow zones, test
 
 #### Create the Yellow Zone Agent
 
-1. Select **Home** in the left navigation to return to the main page.
+1. In the left navigation, select **Agents**.
 
-1. In the **"What would you like to build?"** pane, copy and paste the following text:
+1. On the Agents list, select the **down-arrow (chevron)** next to **New Agent**, then choose **New classic agent**.
+
+1. In the **Name your agent** dialog, enter the following and select **Create**:
 
     ```text
-    Help me build an agent that knows everything about building agents in Power Platform Copilot Studio. You're an expert, you're a coach, you give proactive advice on how to build Copilot Studio agents. And your knowledge is built on top of learn.microsoft.com as a public website.
+    Copilot Studio Advisor [YourUsername]
     ```
 
-1. Before selecting the blue arrow, select the **Settings** wheel icon again.
-
-1. In the Settings pane, select the **Solution** you just created (named with your username).
-
-1. Give your agent a schema name similar to the Green zone but with `yellow` in it.
+1. After the classic agent canvas opens, select **Settings** (gear icon) and confirm the agent is saved into the **Solution** you just created (named with your username). Give your agent a schema name similar to the Green zone but with `yellow` in it.
 
     > [!TIP]
     > For example: `mcs_build_advisor_[YourUsername]_yellow`. Keeping a consistent naming pattern across zones helps you stay organized.
 
-1. Select the **blue arrow** to create the agent in the Bootcamp Yellow environment.
+1. A **New classic agent** is created blank. In the **Instructions** section, select **Edit**, paste the following, and save:
 
-1. Wait for the agent to be created. Your screen will say _"Getting things ready"_.
-
-1. Once ready, verify that the agent has your name, description, and auto-generated instructions.
-
-1. Scroll down and notice the knowledge suggestions again. You can add a couple that make sense for you.
+    ```text
+    You are an expert coach for building agents in Power Platform Copilot Studio. You give proactive, practical advice on how to design, build, and govern Copilot Studio agents. Ground your answers in the Microsoft Learn (learn.microsoft.com) public website that has been added as knowledge, and cite the pages you use. If a question cannot be answered from that knowledge, say so plainly rather than guessing.
+    ```
 
 #### Add Public Website Knowledge (Microsoft Learn)
 
@@ -501,36 +484,34 @@ Create a "Copilot Studio Advisor" agent in the Red zone with full public website
 
 #### Create the Red Zone Agent
 
-1. Select **Home** in the left navigation to return to the main page.
+1. In the left navigation, select **Agents**.
 
-1. In the **"What would you like to build?"** pane, copy and paste the following text:
+1. On the Agents list, select the **down-arrow (chevron)** next to **New Agent**, then choose **New classic agent**.
+
+1. In the **Name your agent** dialog, enter the following and select **Create**:
 
     ```text
-    Help me build an agent that knows everything about building agents in Power Platform Copilot Studio. You're an expert, you're a coach, you give proactive advice on how to build Copilot Studio agents. And your knowledge is built on top of the following sources:
-    https://learn.microsoft.com, https://microsoft.github.io/mcscatblog/
+    Copilot Studio Advisor [YourUsername]
     ```
 
-    > [!NOTE]
-    > The URLs provided are great resources to be used for learning more about Copilot Studio.
-
-1. Select the **Settings** wheel icon.
-
-1. In the Settings pane, select the **Solution** you just created (named with your username).
-
-1. Give your agent a schema name with `red` in it, following the same pattern as before.
+1. After the classic agent canvas opens, select **Settings** (gear icon) and confirm the agent is saved into the **Solution** you just created (named with your username). Give your agent a schema name with `red` in it, following the same pattern as before.
 
     > [!TIP]
     > For example: `mcs_build_advisor_[YourUsername]_red`
 
-1. Select the **blue arrow** to create the agent.
+1. A **New classic agent** is created blank. In the **Instructions** section, select **Edit**, paste the following, and save:
 
-1. Wait for the agent to be created.
+    ```text
+    You are an expert coach for building agents in Power Platform Copilot Studio. You give proactive, practical advice on how to design, build, and govern Copilot Studio agents. Ground your answers in the public website knowledge sources that have been added (Microsoft Learn and the MCS CAT blog), and cite the pages you use. Prefer authoritative, official sources when they conflict with community content.
+    ```
 
-1. Once ready, verify your agent has the correct name, description, and instructions.
-
-1. Scroll down. You should see that the URLs you provided in the prompt have been added as suggestions.
+    > [!NOTE]
+    > These are great resources for learning more about Copilot Studio: `https://learn.microsoft.com` and `https://microsoft.github.io/mcscatblog/`. You will add them as knowledge in the next section.
 
 #### Add Public Website Knowledge
+
+> [!NOTE]
+> **Suggested knowledge sources may not appear.** The "suggested knowledge sources" prompts described below were generated by the older conversational (describe-driven) build flow. When the agent is created via **New classic agent**, the classic editor does **not** auto-suggest knowledge sources from a prompt. If you do not see a suggestions pane, add each public website manually: select the **Knowledge** tab → **Add knowledge** → **Public websites**, then add `learn.microsoft.com` and `microsoft.github.io/mcscatblog` one at a time. (This step is flagged for author redesign.)
 
 1. In the suggestions pane, select **Add** next to the suggested knowledge sources. If for any reason your browser refreshes the list of suggestions will not be there.
 

--- a/labs/mcs-governance/README.md
+++ b/labs/mcs-governance/README.md
@@ -165,45 +165,32 @@ Create a "Copilot Studio Advisor" agent in both the Green and Yellow zones, test
 
 #### Create the Agent
 
-1. Select **Home** in the left navigation to return to the main page.
+1. In the left navigation, select **Agents**.
 
-1. In the **"What would you like to build?"** pane, find the text area that says _"Start building by describing what your agent needs to do"_.
+1. On the Agents list, select the **down-arrow (chevron)** next to **New Agent**, then choose **New classic agent**.
 
-1. Enter the following text into the description field, but do not send it yet you will be adding more in the next step:
+    > [!NOTE]
+    > Keep the **New experience** toggle **ON**. **New classic agent** opens the classic canvas in a new browser tab without switching your experience. The first time you do this you may see a one-time **Welcome to Microsoft Copilot Studio** dialog — select **Get Started**. If that dialog is stacked behind the **Name your agent** dialog, select **Cancel**, complete **Get Started**, then retry **New classic agent**.
 
-    ```text
-    Help me build an agent that knows everything about building agents in Power Platform Copilot Studio. You're an expert, you're a coach, you give proactive advice on how to build Copilot Studio agents. And your knowledge is built on top of a SharePoint document.
-    ```
-
-1. After typing the description, add the following **SharePoint link** to the end of the instructions
-
-    ```
-    Here is the document to use as knowledge: https://copilotstudiotraining.sharepoint.com/:p:/s/Workshop/IQDYEPT5O76JR5akoXWdwO-PAR3IVlIBJ-RqZqpHy2cCRLs?e=qpIVD6
-    ```
-
-1. At the end of your instructions, add the following text:
+1. In the **Name your agent** dialog, enter the following and select **Create**:
 
     ```text
-    Please name this agent Copilot Studio Advisor [YourUsername]
+    Copilot Studio Advisor [YourUsername]
     ```
 
     > [!NOTE]
     > We add the username so we can find your agent easily in this shared environment.
 
-1. Before selecting the blue arrow to create, select the **Settings** wheel icon in the bottom-left corner.
-
-1. In the Settings pane, select the **Solution** you created earlier in this lab (named with your username).
-
-1. Optionally, give your agent a custom **Schema Name**.
+1. After the classic agent canvas opens, select **Settings** (gear icon) and confirm the agent is saved into the **Solution** you created earlier in this lab (named with your username). Optionally, give your agent a custom **Schema Name**.
 
     > [!TIP]
     > Schema names are used for advanced management of your agents. We advise using schema names in collaboration with the description. For example: `mcs_build_advisor_[YourUsername]_green`. Include the zone name (green, yellow, red) so you can tell them apart later.
 
-1. Select the **blue arrow** on the right side to submit and create your agent.
+1. A **New classic agent** is created blank — empty Instructions, default system topics, and the model defaults to Claude Sonnet 4.6. In the **Instructions** section, select **Edit**, paste the following, and save:
 
-1. Wait for Copilot Studio to build your agent. It will generate your name, description, and auto-generated instructions.
-
-1. Scroll down and notice that Copilot Studio has added suggested knowledge sources such as training hands-on labs, PowerPoint decks, and other capabilities.
+    ```text
+    You are an expert coach for building agents in Power Platform Copilot Studio. You give proactive, practical advice on how to design, build, and govern Copilot Studio agents. Ground every answer in the SharePoint Implementation Guide that has been added as knowledge, and cite it when you can. If a question cannot be answered from that knowledge, say so plainly rather than guessing.
+    ```
 
 #### Add SharePoint Knowledge
 
@@ -293,28 +280,26 @@ Create a "Copilot Studio Advisor" agent in both the Green and Yellow zones, test
 
 1. Search for and select `Bootcamp Yellow`.
 
-1. In the **"What would you like to build?"** pane, copy and paste the following text:
+1. In the left navigation, select **Agents**.
+
+1. On the Agents list, select the **down-arrow (chevron)** next to **New Agent**, then choose **New classic agent**.
+
+1. In the **Name your agent** dialog, enter the following and select **Create**:
 
     ```text
-    Help me build an agent that knows everything about building agents in Power Platform Copilot Studio. You're an expert, you're a coach, you give proactive advice on how to build Copilot Studio agents. And your knowledge is built on top of learn.microsoft.com as a public website.
+    Copilot Studio Advisor [YourUsername]
     ```
 
-1. Before selecting the blue arrow, select the **Settings** wheel icon again.
-
-1. Double-check that the correct **Solution** is selected.
-
-1. Give your agent a schema name similar to the Green zone but with `yellow` in it.
+1. After the classic agent canvas opens, select **Settings** (gear icon) and double-check that the correct **Solution** is selected. Give your agent a schema name similar to the Green zone but with `yellow` in it.
 
     > [!TIP]
     > For example: `mcs_build_advisor_[YourUsername]_yellow`. Keeping a consistent naming pattern across zones helps you stay organized.
 
-1. Select the **blue arrow** to create the agent in the Bootcamp Yellow environment.
+1. A **New classic agent** is created blank. In the **Instructions** section, select **Edit**, paste the following, and save:
 
-1. Wait for the agent to be created. Your screen will say _"Getting things ready"_.
-
-1. Once ready, verify that the agent has your name, description, and auto-generated instructions.
-
-1. Scroll down and notice the knowledge suggestions again. You can add a couple that make sense for you.
+    ```text
+    You are an expert coach for building agents in Power Platform Copilot Studio. You give proactive, practical advice on how to design, build, and govern Copilot Studio agents. Ground your answers in the Microsoft Learn (learn.microsoft.com) public website that has been added as knowledge, and cite the pages you use. If a question cannot be answered from that knowledge, say so plainly rather than guessing.
+    ```
 
 #### Add Public Website Knowledge (Microsoft Learn)
 
@@ -444,34 +429,34 @@ Create a "Copilot Studio Advisor" agent in the Red zone with full public website
 
 1. Search for and select `Bootcamp Red`.
 
-1. In the **"What would you like to build?"** pane, copy and paste the following text:
+1. In the left navigation, select **Agents**.
+
+1. On the Agents list, select the **down-arrow (chevron)** next to **New Agent**, then choose **New classic agent**.
+
+1. In the **Name your agent** dialog, enter the following and select **Create**:
 
     ```text
-    Help me build an agent that knows everything about building agents in Power Platform Copilot Studio. You're an expert, you're a coach, you give proactive advice on how to build Copilot Studio agents. And your knowledge is built on top of the following sources:
-    https://learn.microsoft.com, https://microsoft.github.io/mcscatblog/
+    Copilot Studio Advisor [YourUsername]
+    ```
+
+1. After the classic agent canvas opens, select **Settings** (gear icon) and double-check your **Solution**. Give your agent a schema name with `red` in it, following the same pattern as before.
+
+    > [!TIP]
+    > For example: `mcs_build_advisor_[YourUsername]_red`
+
+1. A **New classic agent** is created blank. In the **Instructions** section, select **Edit**, paste the following, and save:
+
+    ```text
+    You are an expert coach for building agents in Power Platform Copilot Studio. You give proactive, practical advice on how to design, build, and govern Copilot Studio agents. Ground your answers in the public website knowledge sources that have been added (Microsoft Learn and the MCS CAT blog), and cite the pages you use. Prefer authoritative, official sources when they conflict with community content.
     ```
 
     > [!NOTE]
-    > The URLs provided are great resources to be used for learning more about Copilot Studio.
-
-1. Select the **Settings** wheel icon.
-
-1. Double-check your **Solution**.
-
-1. Give your agent a schema name with `red` in it, following the same pattern as before.
-
-> [!TIP]
-> For example: `mcs_build_advisor_[YourUsername]_red`
-
-1. Select the **blue arrow** to create the agent.
-
-1. Wait for the agent to be created.
-
-1. Once ready, verify your agent has the correct name, description, and instructions.
-
-1. Scroll down. You should see that the URLs you provided in the prompt have been added as suggestions.
+    > These are great resources for learning more about Copilot Studio: `https://learn.microsoft.com` and `https://microsoft.github.io/mcscatblog/`. You will add them as knowledge in the next section.
 
 #### Add Public Website Knowledge
+
+> [!NOTE]
+> **Suggested knowledge sources may not appear.** The "suggested knowledge sources" prompts described below were generated by the older conversational (describe-driven) build flow. When the agent is created via **New classic agent**, the classic editor does **not** auto-suggest knowledge sources from a prompt. If you do not see a suggestions pane, add each public website manually: select the **Knowledge** tab → **Add knowledge** → **Public websites**, then add `learn.microsoft.com` and `microsoft.github.io/mcscatblog` one at a time. (This step is flagged for author redesign.)
 
 1. In the suggestions pane, select **Add** next to the suggested knowledge sources. If for any reason your browser refreshes the list of suggestions will not be there.
 


### PR DESCRIPTION
Closes #440

Fixes the agent-creation UX drift in the **mcs-governance** lab. This is a describe-driven, three-agent lab: the same agent is created in the Green, Yellow, and Red zones, each previously using the deprecated Home **"What would you like to build?"** conversational build flow.

## What changed

- **3 creates rewritten** (Green, Yellow, Red) to the current flow: **Agents** list → **New Agent** down-arrow (chevron) → **New classic agent** → **Name your agent** → **Create**. Each zone keeps its agent name (`Copilot Studio Advisor [YourUsername]`).
- **Manual Instructions step added after each create** — New classic agent is created blank (empty Instructions, default system topics, model defaults to Claude Sonnet 4.6), so a per-zone Instructions block is now pasted via **Instructions → Edit → save**. The "review the generated instructions" wording was removed.
- **New-experience NOTE** added near the first create: keep **New experience** toggle ON; New classic agent opens the classic canvas in a new tab; one-time **Welcome to Microsoft Copilot Studio** consent handling.
- **Suggested-knowledge-source caveat** — the Red-zone (and Yellow-zone) "suggested knowledge sources" steps depend on the describe-driven build and do **not** work under New classic agent. These were **not** rewritten; instead a clearly-labeled NOTE warns learners to add the public websites manually. The steps are flagged for author redesign in the **Needs author attention** section of #440.
- Applied consistently to both `_labs/mcs-governance.md` and `labs/mcs-governance/README.md` (the source README **does** exist, contrary to the static pass).
- Text-only fix — this lab references no screenshots and has no `images/` directory, so no image was added (avoids an orphan).

## Author review flags

- The per-zone **drafted Instructions** blocks should be reviewed for tone/accuracy.
- The **suggested-knowledge-source steps** need redesign for the classic flow (see #440).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
