### PR TITLE
core-concepts-variables-agents-channels: fix audit findings from #444

### DIFF
--- a/_labs/core-concepts-variables-agents-channels.md
+++ b/_labs/core-concepts-variables-agents-channels.md
@@ -319,7 +319,7 @@ Create a specialized child agent and configure the parent agent to orchestrate c
 
 1. In your Copilot Studio Assistant agent, Select  **Agents**  in the agent top navigation bar.
 
-1. Select  **Add**.
+1. Select  **Add an agent**.
 
 1. In the **Create a child agent** section, Select **New child agent**.
 
@@ -499,7 +499,7 @@ Deploy your agent to Teams and Microsoft 365 Copilot channels with proper config
    - **SharePoint**: Deploy as a SharePoint-grounded agent
    - **Web app**: Embeddable web widget for your sites
    - **Native app**: iOS and Android integration
-   - **Direct Line Speech** / **Email** / **Dynamics 365 Customer Service** / **Genesys** / **LivePerson**: Specialized service channels
+   - **Direct Line Speech** / **Email** / **Dynamics 365 Contact Center** / **Genesys** / **LivePerson**: Specialized service channels
    - Social / messaging: **Facebook**, **WhatsApp**, **Slack**, **Telegram**, **Twilio**, **Line**, **GroupMe**
 
     > [!NOTE]

--- a/labs/core-concepts-variables-agents-channels/README.md
+++ b/labs/core-concepts-variables-agents-channels/README.md
@@ -296,7 +296,7 @@ Create a specialized child agent and configure the parent agent to orchestrate c
 
 1. In your Copilot Studio Assistant agent, Select  **Agents**  in the agent top navigation bar.
 
-1. Select  **Add**.
+1. Select  **Add an agent**.
 
 1. In the **Create a child agent** section, Select **New child agent**.
 


### PR DESCRIPTION
Closes #444

Fixes two interactive-verified low content nits from audit run `2026-06-18T1231Z-b55b` (verified live as user 4W83Z7BM):

- **UC#2** — the lab said to select **Add** to add a child agent; the live button is labeled **Add an agent**. Updated in both the learner file (`_labs/core-concepts-variables-agents-channels.md`) and the source README (`labs/core-concepts-variables-agents-channels/README.md`).
- **UC#3** — the channel inventory listed **Dynamics 365 Customer Service**; the live tile is now **Dynamics 365 Contact Center**. Updated in the learner file. The source README's UC#3 channel list does not contain that label, so no change was needed there.

Only these specific labels were changed; no other steps were rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)