### PR TITLE
agent-builder-m365: fix audit findings from #446

### DIFF
--- a/_labs/agent-builder-m365.md
+++ b/_labs/agent-builder-m365.md
@@ -245,7 +245,7 @@ Create, configure, and test a web-based Copilot agent that serves as a knowledge
 
 #### Create your learning assistant agent
 
-6. On the left side navigation pane, expand the **Agents** section and select **New agent**
+6. On the left side navigation pane, select **Agents** to open the **Agent Store**, then select **Create agent** (or the **New agent** card)
 
 
 7. Notice that you can explore existing available templates. For this lab, paste the following into the **Describe the agent you want to create** input area at the top of the form (the describe textbox is the primary input — there is no separate tab to select), and then select Send.
@@ -293,7 +293,7 @@ Create, configure, and test a web-based Copilot agent that serves as a knowledge
 
 11. Now review the **Configure** tab on the right side of Agent Builder. Notice how all of your previous interactions have built the configuration of your agent, its name, description, instructions, knowledge sources and starter prompts — populated incrementally during the conversational creation. Feel free to tweak them!
 
-12. In the **Knowledge** section, confirm **Only use specified sources** is enabled (the toggle is on by default once knowledge sources are added; toggle it on if it is not) so that the agent uses the configured websites when providing answers, and not its own large language model knowledge.
+12. In the **Knowledge** section, after adding knowledge sources, turn **Only use specified sources** **on** (it is not enabled automatically) so that the agent uses the configured websites when providing answers, and not its own large language model knowledge.
 
 13. Fix any issue like max character limit for starter prompt titles.
 
@@ -408,7 +408,7 @@ Build a sophisticated Sales Admin Assistant that integrates organizational data 
 
 5. Return to [Microsoft 365 Copilot](https://m365.cloud.microsoft/chat/?auth=2&home=1).
 
-6. On the left side pane, expand **Agents** and select **New agent**.
+6. On the left side pane, select **Agents** to open the **Agent Store**, then select **Create agent** (or the **New agent** card).
 
 7. In the **Describe the agent you want to create** textbox at the top of the new agent page, paste the following prompt and press Send (or Enter). The describe textbox is the primary input — there is no separate tab to select.
 

--- a/labs/agent-builder-m365/README.md
+++ b/labs/agent-builder-m365/README.md
@@ -231,7 +231,7 @@ What are new features in the Microsoft Copilot Studio roadmap?
 
 #### Create your learning assistant agent
 
-6. On the left side navigation pane, expand the **Agents** section and select **New agent**
+6. On the left side navigation pane, select **Agents** to open the **Agent Store**, then select **Create agent** (or the **New agent** card)
 
 
 7. Notice that you can explore existing available templates. But for this lab, you want to select the  **Describe** tab at the top of the form and paste the following into the input area for the intial agent prompt input area, and then select Send.
@@ -268,7 +268,7 @@ Use https://learn.microsoft.com/en-us/microsoft-365-copilot/ and https://learn.m
 
 11. Now let's head over to the **Configure** tab. Notice how all of your previous interactions have built the configuration of your agent, its name, description, instructions, knowledge sources and starter prompts. Feel free to tweak them!
 
-12. In the **Knowledge** section, toggle **Only use specified sources** so that the agent uses the configured websites when providing answers, and not its own large language model knowledge.
+12. In the **Knowledge** section, after adding knowledge sources, turn **Only use specified sources** **on** (it is not enabled automatically) so that the agent uses the configured websites when providing answers, and not its own large language model knowledge.
 
 13. Fix any issue like max character limit for starter prompt titles.
 
@@ -387,7 +387,7 @@ Build a sophisticated Sales Admin Assistant that integrates organizational data 
 
 5. Return to [Microsoft 365 Copilot Chat](https://m365.cloud.microsoft/chat/?auth=2&home=1).
 
-6. On the left side pane, expand **Agents** and select **New agent**.
+6. On the left side pane, select **Agents** to open the **Agent Store**, then select **Create agent** (or the **New agent** card).
 
 7. Select the **Describe** tab at the top, and copy/paste the following prompt and select Send:
 


### PR DESCRIPTION
Closes #446

Fixes two low-severity content-drift findings from the agent-builder-m365 audit (run `2026-06-18T1231Z-b55b`), verified live as a M365 Copilot (Premium) user; UC#1 was built end-to-end.

**Finding 1** — "expand the **Agents** section and select **New agent**" implied an inline-expanding rail section. Live, selecting **Agents** opens a full-page **Agent Store**; the create control is **Create agent** (or the **New agent** card on that page). Reworded UC#1 Step 6 and UC#2 Step 6.

**Finding 2** — "**Only use specified sources** is on by default once knowledge sources are added" was inaccurate: that toggle stays **off**; what auto-changes is **Search all websites** turning off. Reworded UC#1 Step 12 to instruct turning **Only use specified sources** on manually.

Both fixes applied consistently to `_labs/agent-builder-m365.md` and `labs/agent-builder-m365/README.md`. No unrelated steps changed. This lab is M365 Agent Builder (not Copilot Studio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
