### PR TITLE
core-concepts-analytics-evaluations: fix audit findings from #448

### DIFF
--- a/_labs/core-concepts-analytics-evaluations.md
+++ b/_labs/core-concepts-analytics-evaluations.md
@@ -165,7 +165,7 @@ Access and interpret agent analytics to measure performance and identify optimiz
 
 #### Navigate to Analytics
 
-1. Go to Copilot Studio and select **Agents** on the left navigation. Open your Copilot Studio Assistant agent and select **Analytics** in the top navigation bar.
+1. Go to Copilot Studio and select **Agents** on the left navigation. Open your Copilot Studio Assistant agent, then select the **more options (…/+N)** overflow on the agent's tab bar and choose **Analytics** (it may not be visible directly on the tab bar).
 
 1. Review the analytics dashboard overview, which typically includes:
    - **Summary metrics**: Total conversations, engaged conversations, resolution rate
@@ -225,7 +225,7 @@ Access and interpret agent analytics to measure performance and identify optimiz
 
 1. This section tracks answer quality across completeness, relevance, and use of knowledge sources. Review your **Answered** and **Unanswered** question percentages. 
 
-1. Select **See details** to go deeper into the answer rate and source analytics.
+1. Select **See questions** to go deeper into the answer rate and source analytics.
 
 1. The **Generated answer rate and quality** panel will open on the right side of the screen.
 
@@ -328,7 +328,7 @@ Create evaluation test sets using four different methods and understand how each
 
 #### Generate Test Cases
 
-1. In your Copilot Studio Assistant agent, select **Evaluation** in the top navigation bar for your agent.
+1. In your Copilot Studio Assistant agent, select the **more options (…/+N)** overflow on the agent's tab bar and choose **Evaluate** (it may not be visible directly on the tab bar).
 
     > [!NOTE]
     > If you don't see the Evaluation option, it may need to be enabled in your environment settings or may not yet be available in your region. Check [Agent Evaluation overview](https://learn.microsoft.com/microsoft-copilot-studio/analytics-agent-evaluation-overview) for availability.
@@ -361,13 +361,13 @@ Create evaluation test sets using four different methods and understand how each
 
 1. You can also select the successful ones to see details like the agent response.
 
-1. When you are done reviewing, select **Evaluation** in the agent top navigation bar to return back to the list of evaluation sets.
+1. When you are done reviewing, select **Evaluate** from the agent's tab bar (via the **more options (…/+N)** overflow if needed) to return back to the list of evaluation sets.
 
 #### Import Test Cases
 
 1. Select **Create a test set** to open the New evaluation page.
 
-1. In the middle of the screen in the **Start by uploading some questions** section, select **CSV** to download the CSV template.
+1. In the middle of the screen in the **Start by uploading some questions** section, select the **template** link to download the sample CSV.
 
 1. Review the required CSV format by opening the file you downloaded. The template shows the expected columns:
     - **question** - User question that the agent will answer

--- a/labs/core-concepts-analytics-evaluations/README.md
+++ b/labs/core-concepts-analytics-evaluations/README.md
@@ -145,7 +145,7 @@ Access and interpret agent analytics to measure performance and identify optimiz
 
 #### Navigate to Analytics
 
-1. Go to Copilot Studio and select **Agents** on the left navigation. Open your Copilot Studio Assistant agent and select **Analytics** in the top navigation bar.
+1. Go to Copilot Studio and select **Agents** on the left navigation. Open your Copilot Studio Assistant agent, then select the **more options (…/+N)** overflow on the agent's tab bar and choose **Analytics** (it may not be visible directly on the tab bar).
 
 1. Review the analytics dashboard overview, which typically includes:
    - **Summary metrics**: Total conversations, engaged conversations, resolution rate
@@ -205,7 +205,7 @@ Access and interpret agent analytics to measure performance and identify optimiz
 
 1. This section tracks answer quality across completeness, relevance, and use of knowledge sources. Review your **Answered** and **Unanswered** question percentages. 
 
-1. Select **See details** to go deeper into the answer rate and source analytics.
+1. Select **See questions** to go deeper into the answer rate and source analytics.
 
 1. The **Generated answer rate and quality** panel will open on the right side of the screen.
 
@@ -308,7 +308,7 @@ Create evaluation test sets using four different methods and understand how each
 
 #### Generate Test Cases
 
-1. In your Copilot Studio Assistant agent, select **Evaluation** in the top navigation bar for your agent.
+1. In your Copilot Studio Assistant agent, select the **more options (…/+N)** overflow on the agent's tab bar and choose **Evaluate** (it may not be visible directly on the tab bar).
 
     > [!NOTE]
     > If you don't see the Evaluation option, it may need to be enabled in your environment settings or may not yet be available in your region. Check [Agent Evaluation overview](https://learn.microsoft.com/microsoft-copilot-studio/analytics-agent-evaluation-overview) for availability.
@@ -345,13 +345,13 @@ Create evaluation test sets using four different methods and understand how each
 
 1. You can also select the successful ones to see details like the agent response.
 
-1. When you are done reviewing, select **Evaluation** in the agent top navigation bar to return back to the list of evaluation sets.
+1. When you are done reviewing, select **Evaluate** from the agent's tab bar (via the **more options (…/+N)** overflow if needed) to return back to the list of evaluation sets.
 
 #### Import Test Cases
 
 1. Select **New evaluation**.
 
-1. In the middle of the screen in the **Start by uploading some questions** section, select **CSV** to download the CSV template.
+1. In the middle of the screen in the **Start by uploading some questions** section, select the **template** link to download the sample CSV.
 
 1. Review the required CSV format by opening the file you downloaded. The template shows the expected columns:
     - **question** - User question that the agent will answer


### PR DESCRIPTION
Closes #448

Fixes 3 low-severity content-drift findings from the `2026-06-18T1231Z-b55b` audit run, verified live against the current Copilot Studio UI as the workshop user (User 4W83Z7BM). Applied consistently to both `_labs/core-concepts-analytics-evaluations.md` and `labs/core-concepts-analytics-evaluations/README.md`.

- **UC1 / UC2 navigation** — Analytics and Evaluate are reached via the agent tab bar's **more options (…/+N)** overflow menu, not "the top navigation bar" (in the New experience the tabs are hidden behind a "+8 / 8 more options" overflow). Reworded the Navigate-to-Analytics step, the Generate-Test-Cases step, and the UC2 "return to evaluation list" step.
- **UC1** — the "Generated answer rate and quality" section button is labeled **See questions**, not **See details**. ("See details" remains correct for the Conversation outcomes section and was left unchanged.)
- **UC2 Import** — the sample CSV is downloaded via the **template** link, not a "CSV" control. Reworded to "select the **template** link to download the sample CSV."

Test-method name nuances (Text similarity / Tool use) and the date-picker-position note were left as-is — the lab already hedges method names adequately and those are out of scope for this low-severity pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)