### PR TITLE
mcs-workflows: fix audit findings from #452 (broken links + UC table sync)

### DIFF
--- a/_labs/mcs-workflows.md
+++ b/_labs/mcs-workflows.md
@@ -91,8 +91,8 @@ This lab is **Use Case #1** of a deeper Workflows module. It establishes the fou
 ## Documentation and Additional Training Links
 
 * [Workflows in Microsoft Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-overview)
-* [Add an agent to a workflow](https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-action-agent)
-* [Triggers for workflows](https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-triggers)
+* [Add an agent to a workflow](https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-node-workflow)
+* [Triggers for workflows](https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-triggers-about)
 * [Add tools to an agent](https://learn.microsoft.com/en-us/microsoft-copilot-studio/add-tools-custom-agent)
 * [Model Context Protocol (MCP) in Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp)
 * [Microsoft To Do](https://to-do.office.com/) · [Outlook Calendar](https://outlook.office.com/calendar/)
@@ -128,6 +128,10 @@ In this lab, you'll build an autonomous Workflow that turns a new to-do into sch
 | Step | Use Case | Value added | Effort |
 |------|----------|-------------|--------|
 | 1 | [Automate Task Time-Blocking with a Workflow and an Inline Agent](#use-case-1-automate-task-time-blocking-with-a-workflow-and-an-inline-agent) | Build an autonomous, trigger-driven Workflow whose inline agent reasons over a task and acts across your calendar and to-do list | 45 min |
+| 2 | [Setting Up the Order Management Workflow](#use-case-2-setting-up-the-order-management-workflow) | Configure connections, fix solution references, transfer ownership, publish, and end-to-end test a pre-built email classification workflow | 30 min |
+| 3 | [Use M365 Copilot and Add a Human-in-the-Loop in Order Management](#use-case-3-use-m365-copilot-and-add-a-human-in-the-loop-in-order-management) | Review a grounded M365 Copilot draft, route it through human approval, and verify the approved response is sent to the customer | 20 min |
+| 4 | [Build an Inline Agent for Inventory Management](#use-case-4-build-an-inline-agent-for-inventory-management) | Add an inline agent that reasons over delay emails, uses MCP tools for warehouse and Dataverse, and returns structured output | 25 min |
+| 5 | [Call a Price Quote Specialist Agent from a Workflow](#use-case-5-call-a-price-quote-specialist-agent-from-a-workflow) | Reuse a published agent with knowledge, MCP tools, and a skill to generate and send a professional customer quote | 20 min |
 
 ---
 

--- a/labs/mcs-workflows/README.md
+++ b/labs/mcs-workflows/README.md
@@ -75,8 +75,8 @@ This lab is **Use Case #1** of a deeper Workflows module. It establishes the fou
 ## 📄 Documentation and Additional Training Links
 
 * [Workflows in Microsoft Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-overview)
-* [Add an agent to a workflow](https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-action-agent)
-* [Triggers for workflows](https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-triggers)
+* [Add an agent to a workflow](https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-node-workflow)
+* [Triggers for workflows](https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-triggers-about)
 * [Add tools to an agent](https://learn.microsoft.com/en-us/microsoft-copilot-studio/add-tools-custom-agent)
 * [Model Context Protocol (MCP) in Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp)
 * [Microsoft To Do](https://to-do.office.com/) · [Outlook Calendar](https://outlook.office.com/calendar/)


### PR DESCRIPTION
Fixes the concrete content bugs from the `mcs-workflows` audit (#452), applied to **both** `README.md` and `_labs/mcs-workflows.md` so the Lab Doc Sync check stays green.

## Findings 1 & 2 — broken Learn links (HIGH)
Both links in *Documentation and Additional Training Links* returned **404**. Replaced with live pages (verified `200`), distinct from the existing `flows-overview` link already in that list:

| Link text | Old (404) | New (200) |
| --- | --- | --- |
| Add an agent to a workflow | `…/flows-action-agent` | [`…/agent-node-workflow`](https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-node-workflow) — "Add an agent node to an agent flow or workflow" |
| Triggers for workflows | `…/flows-triggers` | [`…/authoring-triggers-about`](https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-triggers-about) — "Event triggers overview" |

## Finding 3 — "Use Cases Covered" table incomplete (HIGH)
The README table already listed all 5 use cases, but the **`_labs` copy still listed only UC #1** — and the site renders from `_labs`, so the live lab showed the wrong table. Synced it to all five rows, using `_labs`-style (non-emoji) heading anchors so the links resolve.

## Finding 4 — `section: advanced_labs` (LOW)
**False positive — no change.** `advanced_labs` is the established lab-section convention (5 labs use it; it matches `core_learning_path` / `intermediate_labs` / `specialized_labs`). The audit's suggested `advanced` would be the outlier.

## Not in this PR
Finding 5 (Consumer vs Business To-Do connector ordering) and the interactive comments (UC2 "Assign" navigation path, connectors unavailable in the lab tenant) are doc-clarity / environment items — left for a separate pass rather than risk adding unverified UI steps.

## Verification
- Both new URLs return `200`; old ones confirmed `404`.
- `_labs` table now lists UC #1–#5; anchors match the file's headings.
- Lab Doc Sync check passes locally (both files changed together).

🤖 Generated with [Claude Code](https://claude.com/claude-code)