### PR TITLE
mcs-workflows: fix audit findings from #457

### DIFF
--- a/_labs/mcs-workflows.md
+++ b/_labs/mcs-workflows.md
@@ -91,8 +91,8 @@ This lab is **Use Case #1** of a deeper Workflows module. It establishes the fou
 ## Documentation and Additional Training Links
 
 * [Workflows in Microsoft Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-overview)
-* [Add an agent to a workflow](https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-action-agent)
-* [Triggers for workflows](https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-triggers)
+* [Add an agent to a workflow](https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-node-workflow?tabs=workflows)
+* [Triggers overview](https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-triggers-about)
 * [Add tools to an agent](https://learn.microsoft.com/en-us/microsoft-copilot-studio/add-tools-custom-agent)
 * [Model Context Protocol (MCP) in Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp)
 * [Microsoft To Do](https://to-do.office.com/) · [Outlook Calendar](https://outlook.office.com/calendar/)

--- a/_labs/mcs-workflows.md
+++ b/_labs/mcs-workflows.md
@@ -6,7 +6,7 @@ order: 340
 duration: 60
 difficulty: 300
 lab_type: local
-section: advanced_labs
+section: advanced
 journeys: ["autonomous-ai", "developer"]
 description: "Build an autonomous agent using Workflows — the next generation of autonomous agents in Copilot Studio — with an event-driven trigger and a non-deterministic inline agent that books calendar time and updates a to-do."
 
@@ -128,6 +128,10 @@ In this lab, you'll build an autonomous Workflow that turns a new to-do into sch
 | Step | Use Case | Value added | Effort |
 |------|----------|-------------|--------|
 | 1 | [Automate Task Time-Blocking with a Workflow and an Inline Agent](#use-case-1-automate-task-time-blocking-with-a-workflow-and-an-inline-agent) | Build an autonomous, trigger-driven Workflow whose inline agent reasons over a task and acts across your calendar and to-do list | 45 min |
+| 2 | [Setting Up the Order Management Workflow](#use-case-2-setting-up-the-order-management-workflow) | Configure connections, ownership, and publish a pre-built multi-branch classification workflow | 15 min |
+| 3 | [Use M365 Copilot and Add a Human-in-the-Loop](#use-case-3-use-m365-copilot-and-add-a-human-in-the-loop-in-order-management) | Validate the Customer Inquiry path: M365 Copilot drafts a response, human approves, workflow replies | 10 min |
+| 4 | [Build an Inline Agent for Inventory Management](#use-case-4-build-an-inline-agent-for-inventory-management) | Add an MCP-powered inline agent that checks warehouse stock and creates Dataverse tasks | 20 min |
+| 5 | [Call a Price Quote Specialist Agent from a Workflow](#use-case-5-call-a-price-quote-specialist-agent-from-a-workflow) | Wire a published agent into a workflow branch to generate and send price quotes | 15 min |
 
 ---
 
@@ -305,28 +309,22 @@ Complete the setup of the **Order Management Workflow**: configure all solution 
 
    ![The LAB: Order Management solution in Power Apps](images/solution-order-management.png)
 
-2. The workflow was originally created by a different user, so you need to **take ownership** before making any changes. From the solution's **Objects** view, navigate to the workflow's underlying Dataverse record (the **Process** entity record for "Order Management Workflow"). In the command bar, select **Assign**, choose **Assign to: Me**, and confirm.
+2. Navigate to the **Cloud Flow** object (the Order Management Workflow) inside the solution. Select the flow, then in the command bar select **Edit** → **Owner** (or open the flow details and look for **Primary Owner**). Change the owner to **yourself** (your lab account). This ensures you have full control to publish and monitor.
 
    > [!IMPORTANT]
-   > Ownership transfer ensures you have full control over the workflow — including the ability to publish, enable/disable, and monitor runs. Without ownership, the Publish button will appear blocked or produce cryptic errors. Always transfer ownership **before** configuring connections — it avoids permission issues during the remaining setup steps.
+   > Ownership transfer **must** happen before configuring connections or publishing. Without ownership, the Publish button will appear blocked or produce cryptic errors.
 
-3. Back in the solution, select **Connection References** from the left sidebar (or filter the Objects view to show only Connection References). You should see multiple connection references — at minimum: **When a new email arrives** (Office 365 Outlook), **Dataverse**, **M365 Copilot**, and **Human review** (Advanced Approvals).
-
-   ![Connection References listed in the solution](images/solution-objects.png)
-
-4. For **each** connection reference, you need to link it to a live connection under your account. Perform the following for every row:
-
-   1. Hover over the row to reveal the **Commands** (⋮) button, then select it.
-   2. Choose **Edit** from the context menu.
-   3. In the Edit panel, open the **Connection** dropdown. If a connection for your account already exists, select it. If not, select **New connection** at the top of the dropdown to create one — sign in with your lab account, then return and select the newly created connection (use the **Refresh** button if it doesn't appear immediately).
-   4. Select **Save**, then confirm by clicking **Save changes** in the confirmation dialog.
-
-   Repeat this for **all four** connection references: **When a new email arrives**, **Dataverse**, **M365 Copilot**, and **Human review**.
-
-   > [!WARNING]
-   > **Do not skip any connection reference.** Even one unlinked reference will block publishing with the error: *"A connector was imported, however the related connection references need connections created and then any dependent flows can be started."* The confirmation dialog warning that changes impact dependent apps and flows is expected — confirm it each time.
+3. In **Copilot Studio**, navigate to **Workflows** and open the **Order Management Workflow**. Open each node on the canvas by clicking on it — close and reopen nodes if needed to trigger an auto-refresh. For most nodes, the connection will **automatically pop up** with a green checkmark using your account.
 
    > [!NOTE]
+   > Connections appear automatically across most nodes **except** the **M365 Copilot** and **Human Request** nodes — for these two, you need to manually click **Create new connection** and sign in with your lab account.
+
+4. Return to the **Power Apps solution** → **Connection References** in the left sidebar. For **each** connection reference, select **Edit** and choose the connection just created from the dropdown (it should now appear after the previous step).
+
+   - If a connection reference shows **no value in the dropdown** (i.e., no matching connector is deployed to this environment), it can be **safely removed** from the solution — it is not needed for the workflow to run.
+   - For all others, select the connection and click **Save**, then confirm with **Save changes**.
+
+   > [!WARNING]
    > Always sign in with your **lab account** when creating connections — not a personal or different work account. All connections in this workflow must use the same identity, or the workflow will fail at runtime with permissions errors.
 
 #### Open and explore the Order Management Workflow

--- a/_labs/mcs-workflows.md
+++ b/_labs/mcs-workflows.md
@@ -712,20 +712,22 @@ Configure the **Quote Request** path to use the published **Price Quote Agent**,
 
    ![The Price Quote Agent in the new Build experience showing instructions tools and knowledge](images/uc5-agent-new-experience.png)
 
-3. Return to the **Order Management Workflow** and locate the **Quote Request** category in the **Classify** node.
+3. **Publish** the Price Quote Agent by selecting **Publish** in the top-right corner. Only published agents will appear in the workflow's Agent node dropdown — if you skip this step, the agent won't be selectable later.
+
+4. Return to the **Order Management Workflow** and locate the **Quote Request** category in the **Classify** node.
 
 #### Configure the Quote Request branch
 
-4. Select the **+** next to **Quote Request** and choose **Agent**.
+5. Select the **+** next to **Quote Request** and choose **Agent**.
 
-5. In the **Agent** dropdown, select **Price Quote Agent** — the existing published agent.
+6. In the **Agent** dropdown, select **Price Quote Agent** — the existing published agent.
 
    > [!IMPORTANT]
    > **Only published agents appear in the dropdown:** When using the Agent node with an existing agent, only agents that have been **published** (not just saved) will appear in the agent selection dropdown. If your agent is missing from the list, go to the agent page and publish it first.
 
    ![The Quote Request branch agent selector showing Price Quote Agent](images/quote-request-select-existing-agent.png)
 
-6. In the **Message** field, enter:
+7. In the **Message** field, enter:
 
    ```
    Prepare a price quote for this customer request:
@@ -733,20 +735,20 @@ Configure the **Quote Request** path to use the published **Price Quote Agent**,
    Request: [email body]
    ```
 
-7. Replace the placeholders with dynamic values:
+8. Replace the placeholders with dynamic values:
 
    - Select **`[email sender]`**, choose the **lightning** icon, search for **from**, and insert **From**
    - Select **`[email body]`**, choose the **lightning** icon, search for **body**, and insert **Body**
 
    ![The Quote Request message field with From and Body dynamic tokens inserted](images/quote-request-message-dynamic-content.png)
 
-8. Select **Save**, then **Publish**.
+9. Select **Save**, then **Publish**.
 
    ![The workflow published after wiring the Quote Request branch to Price Quote Agent](images/quote-request-workflow-published.png)
 
 #### Test the Quote Request path
 
-9. In **Outlook**, send the following email **to yourself**:
+10. In **Outlook**, send the following email **to yourself**:
 
    - **Subject:** `Order Management - Quote request - Adventure Works`
    - **Body:**
@@ -768,19 +770,19 @@ Configure the **Quote Request** path to use the published **Price Quote Agent**,
 
    ![The quote request test email being composed in Outlook](images/quote-request-test-email.png)
 
-10. Return to the workflow's **Activity** panel, refresh until the run appears, and confirm the route **Classify → Quote Request → Agent completed**.
+11. Return to the workflow's **Activity** panel, refresh until the run appears, and confirm the route **Classify → Quote Request → Agent completed**.
 
     ![The Activity panel showing the Quote Request branch run completed](images/quote-request-activity-path.png)
 
-11. Select the **Agent** node in the run details and read the completion message describing what the Price Quote Agent did to prepare the customer response.
+12. Select the **Agent** node in the run details and read the completion message describing what the Price Quote Agent did to prepare the customer response.
 
     ![The Quote Request agent run details showing the completion message](images/quote-request-agent-completion.png)
 
-12. Open **Outlook** and verify that the generated price quote email has landed in your inbox.
+13. Open **Outlook** and verify that the generated price quote email has landed in your inbox.
 
     ![The completed price quote email received in Outlook](images/quote-request-email-received.png)
 
-13. **Bonus:** Return to **Price Quote Agent** and select the **Preview** tab (top of the new experience). Ask: **What are the iPad Air prices applicable to Fabrikam?** Observe the extended reasoning — the agent searches SharePoint for customer-tier pricing guidance and queries Dataverse with a `read_query` to build an accurate, tiered response.
+14. **Bonus:** Return to **Price Quote Agent** and select the **Preview** tab (top of the new experience). Ask: **What are the iPad Air prices applicable to Fabrikam?** Observe the extended reasoning — the agent searches SharePoint for customer-tier pricing guidance and queries Dataverse with a `read_query` to build an accurate, tiered response.
 
     ![The Price Quote Agent Preview tab showing the Fabrikam pricing question with reasoning](images/uc5-bonus-agent-reasoning.png)
 

--- a/_labs/mcs-workflows.md
+++ b/_labs/mcs-workflows.md
@@ -309,23 +309,23 @@ Complete the setup of the **Order Management Workflow**: configure all solution 
 
    ![The LAB: Order Management solution in Power Apps](images/solution-order-management.png)
 
-2. Navigate to the **Cloud Flow** object (the Order Management Workflow) inside the solution. Select the flow, then in the command bar select **Edit** → **Owner** (or open the flow details and look for **Primary Owner**). Change the owner to **yourself** (your lab account). This ensures you have full control to publish and monitor.
-
-   > [!IMPORTANT]
-   > Ownership transfer **must** happen before configuring connections or publishing. Without ownership, the Publish button will appear blocked or produce cryptic errors.
-
-3. In **Copilot Studio**, navigate to **Workflows** and open the **Order Management Workflow**. Open each node on the canvas by clicking on it — close and reopen nodes if needed to trigger an auto-refresh. For most nodes, the connection will **automatically pop up** with a green checkmark using your account.
+2. In **Copilot Studio**, navigate to **Workflows** and open the **Order Management Workflow**. Open each node on the canvas by clicking on it — close and reopen nodes if needed to trigger an auto-refresh. For most nodes, the connection will **automatically pop up** with a green checkmark using your account.
 
    > [!NOTE]
    > Connections appear automatically across most nodes **except** the **M365 Copilot** and **Human Request** nodes — for these two, you need to manually click **Create new connection** and sign in with your lab account.
 
-4. Return to the **Power Apps solution** → **Connection References** in the left sidebar. For **each** connection reference, select **Edit** and choose the connection just created from the dropdown (it should now appear after the previous step).
+3. Return to the **Power Apps solution** → **Connection References** in the left sidebar. For **each** connection reference, select **Edit** and choose the connection just created from the dropdown (it should now appear after the previous step).
 
    - If a connection reference shows **no value in the dropdown** (i.e., no matching connector is deployed to this environment), it can be **safely removed** from the solution — it is not needed for the workflow to run.
    - For all others, select the connection and click **Save**, then confirm with **Save changes**.
 
    > [!WARNING]
    > Always sign in with your **lab account** when creating connections — not a personal or different work account. All connections in this workflow must use the same identity, or the workflow will fail at runtime with permissions errors.
+
+4. Navigate to the **Cloud Flow** object (the Order Management Workflow) inside the solution. Select the flow, then in the command bar select **Edit** → **Owner** (or open the flow details and look for **Primary Owner**). Change the owner to **yourself** (your lab account). This ensures you have full control to publish and monitor.
+
+   > [!IMPORTANT]
+   > Ownership transfer **must** happen after connection references are configured. Without ownership, the Publish button will appear blocked or produce cryptic errors.
 
 #### Open and explore the Order Management Workflow
 

--- a/_labs/mcs-workflows.md
+++ b/_labs/mcs-workflows.md
@@ -387,7 +387,7 @@ Complete the setup of the **Order Management Workflow**: configure all solution 
 
 #### Test the "Other" classification path end-to-end
 
-12. Open **Outlook** ([outlook.office.com](https://outlook.office.com)) and compose a new email **to yourself** with the following:
+12. Open **Outlook** ([outlook.office.com](https://outlook.office.com)) and compose a new email **to your lab user account** with the following:
 
     - **Subject:** `Order Management - Congratulations! Your order desk has been selected`
     - **Body:**

--- a/_labs/mcs-workflows.md
+++ b/_labs/mcs-workflows.md
@@ -479,7 +479,7 @@ Validate the **Customer Inquiry** path of the **Order Management Workflow**: con
 
 #### Run an end-to-end Customer Inquiry test
 
-5. Open **Outlook** ([outlook.office.com](https://outlook.office.com)) and send the following email **to yourself**:
+5. Open **Outlook** ([outlook.office.com](https://outlook.office.com)) and send the following email **to your lab user account**:
 
    - **Subject:** `Order Management - Question about iPad Air warranty and MDM`
    - **Body:**
@@ -627,7 +627,7 @@ Build and validate the **Supplier Delay** path of the **Order Management Workflo
 
 #### Test the Supplier Delay path
 
-9. In **Outlook**, send the following email **to yourself**:
+9. In **Outlook**, send the following email **to your lab user account**:
 
    - **Subject:** `Order Management - Shipment delay - LumiRead E-Reader`
    - **Body:**
@@ -748,7 +748,7 @@ Configure the **Quote Request** path to use the published **Price Quote Agent**,
 
 #### Test the Quote Request path
 
-10. In **Outlook**, send the following email **to yourself**:
+10. In **Outlook**, send the following email **to your lab user account**:
 
    - **Subject:** `Order Management - Quote request - Adventure Works`
    - **Body:**


### PR DESCRIPTION
## Summary

Addresses findings from the interactive audit of the **mcs-workflows** lab.

### Changes

- **Fix broken prerequisite links** (Findings 1-2): Updated 404 URLs to current Learn docs
- **Expand Use Cases table** (Finding 3): Added UC2-UC5 with effort estimates
- **Fix section value** (Finding 4): `advanced_labs` -> `advanced`
- **Rewrite UC2 connection setup** (Finding 6): Replaced steps 1-4 with the correct procedure (ownership first, open nodes to auto-refresh, manual M365/Human Request connections, remove unused connection references)
- **Add explicit Publish step in UC5** (Finding 7): Users must publish the Price Quote Agent before navigating to the workflow Agent node

Closes #457