### PR TITLE
mcs-workflows: fix broken doc links in README source

### DIFF
--- a/labs/mcs-workflows/README.md
+++ b/labs/mcs-workflows/README.md
@@ -75,8 +75,8 @@ This lab is **Use Case #1** of a deeper Workflows module. It establishes the fou
 ## 📄 Documentation and Additional Training Links
 
 * [Workflows in Microsoft Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-overview)
-* [Add an agent to a workflow](https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-action-agent)
-* [Triggers for workflows](https://learn.microsoft.com/en-us/microsoft-copilot-studio/flows-triggers)
+* [Add an agent to a workflow](https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-node-workflow?tabs=workflows)
+* [Triggers overview](https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-triggers-about)
 * [Add tools to an agent](https://learn.microsoft.com/en-us/microsoft-copilot-studio/add-tools-custom-agent)
 * [Model Context Protocol (MCP) in Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/agent-extend-action-mcp)
 * [Microsoft To Do](https://to-do.office.com/) · [Outlook Calendar](https://outlook.office.com/calendar/)


### PR DESCRIPTION
## What
Fixes two broken (HTTP 404) documentation links in the **source** lab file `labs/mcs-workflows/README.md` (the "Documentation and Additional Training Links" section):

| Before (404) | After (200) |
|---|---|
| `.../flows-action-agent` | `.../agent-node-workflow?tabs=workflows` |
| `.../flows-triggers` | `.../authoring-triggers-about` (link text: *Triggers overview*) |

## Why
PR #458 already corrected these links in the **auto-generated** `_labs/mcs-workflows.md`, but per the repo's own rules `_labs/*.md` is generated and must not be hand-edited — `labs/*/README.md` is the source of truth. Because the source README was never updated, the broken links **regress the next time `Generate-Labs.ps1` runs**. The live site currently looks correct only because it serves the hand-patched generated file.

This change back-ports the correct targets into the README source so source and generated output agree. After this merges, regenerating `_labs/mcs-workflows.md` produces no change to these links.

## Verification
- Old URLs `flows-action-agent` and `flows-triggers` return **404**.
- New URLs `agent-node-workflow?tabs=workflows` and `authoring-triggers-about` return **200** and match the targets already present in `_labs/mcs-workflows.md`.

_Filed by the mcs-lab-auditor against `microsoft/mcs-labs@47eb407`._
