### PR TITLE
mcs-tools: fix UC#1 blocked classic agent path (#461)

### DIFF
--- a/_labs/mcs-tools.md
+++ b/_labs/mcs-tools.md
@@ -165,12 +165,9 @@ Create a custom connector for the Free Dictionary API, add it as a tool in your 
 
 1. Select **Agents** on the left navigation.
 
-1. Turn **OFF** the **New experience** toggle (look for the banner or toggle at the top of Copilot Studio). When the feedback pop-up appears, select **Submit**. This switches you to the classic Copilot Studio experience, where the classic agent canvas works reliably.
+1. Turn **OFF** the **New experience** toggle (look for the banner or toggle at the top of Copilot Studio). When the feedback pop-up appears, select **Submit**. This switches you to the classic Copilot Studio experience.
 
     ![New Agent split-button menu showing New classic agent](images/new-agent-classic-menu.png)
-
-    > [!NOTE]
-    > Creating a **classic agent** with the **New experience** toggle still ON can leave the **Name your agent** dialog stuck (the **Cancel** control is not selectable). Turning the toggle OFF first avoids this and gives you the classic canvas directly.
 
 1. Select **Agents** in the left navigation, then select **Create blank agent**. In the **Name your agent** dialog, enter `Dictionary Agent` and select **Continue**.
 

--- a/_labs/mcs-tools.md
+++ b/_labs/mcs-tools.md
@@ -444,6 +444,8 @@ Create an agent flow that calculates sales commissions using deterministic busin
 
 1. Go to **Microsoft Copilot Studio** at <a href="https://copilotstudio.microsoft.com" target="_blank">copilotstudio.microsoft.com</a>.
 
+1. Make sure you are in the **New Copilot Studio experience** — look for the banner or toggle at the top and select **Try now** (or turn the **New experience** toggle ON).
+
 1. Select **Agents** on left navigation.
 
 1. From the Agents list, select the down-arrow (chevron) next to **New Agent**, then choose **New classic agent**. In the **Name your agent** dialog, enter `Sales Commission Assistant` and select **Create**.
@@ -610,7 +612,7 @@ Create and configure a Copilot Agent with Dataverse MCP Server integration that 
 
 #### Create and Configure the Agent
 
-1. Go to [Copilot Studio](https://copilotstudio.microsoft.com/). Make sure you are logged in using the credentials for the lab and are in the correct environment.
+1. Go to [Copilot Studio](https://copilotstudio.microsoft.com/). Make sure you are logged in using the credentials for the lab and are in the correct environment, and that you are in the **New Copilot Studio experience** — if a banner or toggle offers it, select **Try now** (or turn the **New experience** toggle ON).
 
 1. Select **Agents** in the left navigation, then select the down-arrow (chevron) next to **New Agent** and choose **New classic agent**. In the **Name your agent** dialog, enter `Contoso Agent` and select **Create**.
 

--- a/_labs/mcs-tools.md
+++ b/_labs/mcs-tools.md
@@ -165,12 +165,14 @@ Create a custom connector for the Free Dictionary API, add it as a tool in your 
 
 1. Select **Agents** on the left navigation.
 
-1. From the Agents list, select the down-arrow (chevron) next to **New Agent**, then choose **New classic agent**. In the **Name your agent** dialog, enter `Dictionary Agent` and select **Create**.
+1. Turn **OFF** the **New experience** toggle (look for the banner or toggle at the top of Copilot Studio). When the feedback pop-up appears, select **Submit**. This switches you to the classic Copilot Studio experience, where the classic agent canvas works reliably.
 
     ![New Agent split-button menu showing New classic agent](images/new-agent-classic-menu.png)
 
     > [!NOTE]
-    > Keep the **New experience** toggle ON — **New classic agent** opens the classic canvas in a new browser tab without switching experiences. A one-time **Welcome to Microsoft Copilot Studio** consent dialog may appear on first sign-in (select **Get Started**; if it stacks behind the **Name your agent** dialog, Cancel, Get Started, then retry).
+    > Creating a **classic agent** with the **New experience** toggle still ON can leave the **Name your agent** dialog stuck (the **Cancel** control is not selectable). Turning the toggle OFF first avoids this and gives you the classic canvas directly.
+
+1. Select **Agents** in the left navigation, then select **Create blank agent**. In the **Name your agent** dialog, enter `Dictionary Agent` and select **Continue**.
 
 1. Once the agent is provisioned, confirm its name is `Dictionary Agent`. If you need to change it, select **Edit** in the **Details** section on **Overview**.
 

--- a/labs/mcs-tools/README.md
+++ b/labs/mcs-tools/README.md
@@ -427,6 +427,8 @@ Create an agent flow that calculates sales commissions using deterministic busin
 
 1. Go to **Microsoft Copilot Studio** at <a href="https://copilotstudio.microsoft.com" target="_blank">copilotstudio.microsoft.com</a>.
 
+1. Make sure you are in the **New Copilot Studio experience** — look for the banner or toggle at the top and select **Try now** (or turn the **New experience** toggle ON).
+
 1. Select **Agents** on left navigation.
 
 1. From the Agents list, select the down-arrow (chevron) next to **New Agent**, then choose **New classic agent**. In the **Name your agent** dialog, enter `Sales Commission Assistant` and select **Create**.
@@ -593,7 +595,7 @@ Create and configure a Copilot Agent with Dataverse MCP Server integration that 
 
 #### Create and Configure the Agent
 
-1. Go to [Copilot Studio](https://copilotstudio.microsoft.com/). Make sure you are logged in using the credentials for the lab and are in the correct environment.
+1. Go to [Copilot Studio](https://copilotstudio.microsoft.com/). Make sure you are logged in using the credentials for the lab and are in the correct environment, and that you are in the **New Copilot Studio experience** — if a banner or toggle offers it, select **Try now** (or turn the **New experience** toggle ON).
 
 1. Select **Agents** in the left navigation, then select the down-arrow (chevron) next to **New Agent** and choose **New classic agent**. In the **Name your agent** dialog, enter `Contoso Agent` and select **Create**.
 

--- a/labs/mcs-tools/README.md
+++ b/labs/mcs-tools/README.md
@@ -148,12 +148,9 @@ Create a custom connector for the Free Dictionary API, add it as a tool in your 
 
 1. Select **Agents** on the left navigation.
 
-1. Turn **OFF** the **New experience** toggle (look for the banner or toggle at the top of Copilot Studio). When the feedback pop-up appears, select **Submit**. This switches you to the classic Copilot Studio experience, where the classic agent canvas works reliably.
+1. Turn **OFF** the **New experience** toggle (look for the banner or toggle at the top of Copilot Studio). When the feedback pop-up appears, select **Submit**. This switches you to the classic Copilot Studio experience.
 
     ![New Agent split-button menu showing New classic agent](images/new-agent-classic-menu.png)
-
-    > [!NOTE]
-    > Creating a **classic agent** with the **New experience** toggle still ON can leave the **Name your agent** dialog stuck (the **Cancel** control is not selectable). Turning the toggle OFF first avoids this and gives you the classic canvas directly.
 
 1. Select **Agents** in the left navigation, then select **Create blank agent**. In the **Name your agent** dialog, enter `Dictionary Agent` and select **Continue**.
 

--- a/labs/mcs-tools/README.md
+++ b/labs/mcs-tools/README.md
@@ -148,12 +148,14 @@ Create a custom connector for the Free Dictionary API, add it as a tool in your 
 
 1. Select **Agents** on the left navigation.
 
-1. From the Agents list, select the down-arrow (chevron) next to **New Agent**, then choose **New classic agent**. In the **Name your agent** dialog, enter `Dictionary Agent` and select **Create**.
+1. Turn **OFF** the **New experience** toggle (look for the banner or toggle at the top of Copilot Studio). When the feedback pop-up appears, select **Submit**. This switches you to the classic Copilot Studio experience, where the classic agent canvas works reliably.
 
     ![New Agent split-button menu showing New classic agent](images/new-agent-classic-menu.png)
 
     > [!NOTE]
-    > Keep the **New experience** toggle ON — **New classic agent** opens the classic canvas in a new browser tab without switching experiences. A one-time **Welcome to Microsoft Copilot Studio** consent dialog may appear on first sign-in (select **Get Started**; if it stacks behind the **Name your agent** dialog, Cancel, Get Started, then retry).
+    > Creating a **classic agent** with the **New experience** toggle still ON can leave the **Name your agent** dialog stuck (the **Cancel** control is not selectable). Turning the toggle OFF first avoids this and gives you the classic canvas directly.
+
+1. Select **Agents** in the left navigation, then select **Create blank agent**. In the **Name your agent** dialog, enter `Dictionary Agent` and select **Continue**.
 
 1. Once the agent is provisioned, confirm its name is `Dictionary Agent`. If you need to change it, select **Edit** in the **Details** section on **Overview**.
 


### PR DESCRIPTION
## Summary
Fixes #461.

Following UC #1 with the **New experience** toggle ON, selecting **New classic agent** via the chevron leaves the **Name your agent** dialog stuck — the **Cancel** control is not selectable, so the flow can't continue or be backed out.

## Change
Replaces the blocked step in UC #1 with the working flow per the issue's suggested fix:

- Toggle **OFF** New experience -> the feedback pop-up appears -> **Submit**
- **Agents** -> **Create blank agent** -> name Dictionary Agent -> **Continue**

Updated the accompanying note to explain why the toggle is turned OFF first.

## Testing
Markdown-only content change to `labs/mcs-tools/README.md`.
