### PR TITLE
mcs-tools: force Dictionary API in UC#1 test (#462)

### DIFF
--- a/_labs/mcs-tools.md
+++ b/_labs/mcs-tools.md
@@ -375,6 +375,11 @@ Create a custom connector for the Free Dictionary API, add it as a tool in your 
     > [!NOTE]
     > Disabling **Allow ungrounded responses** ensures that only your custom connector API provides answers, not the underlying language model. This setting was previously labelled **Use general knowledge** in older Copilot Studio UI.
 
+1. Turn off **Use information from the Web** as well.
+
+    > [!NOTE]
+    > If web grounding is left on, the agent can answer from a web search instead of your custom connector. Turning it off forces the agent to use the Free Dictionary API tool for every query.
+
 1. Select **Save**.
 
 1. Close **Settings** using the **X** in the upper right-hand corner.
@@ -386,11 +391,11 @@ Create a custom connector for the Free Dictionary API, add it as a tool in your 
     ```
 
     ```
-    Where does it come from?
+    How about the word amazing?
     ```
 
     ```
-    How about the word amazing?
+    How do I pronounce the word "leverage" in English?
     ```
 
 1. Verify that the agent uses your custom connector tool to retrieve definitions, origins, and phonetic information from the Free Dictionary API.

--- a/_labs/mcs-tools.md
+++ b/_labs/mcs-tools.md
@@ -377,9 +377,6 @@ Create a custom connector for the Free Dictionary API, add it as a tool in your 
 
 1. Turn off **Use information from the Web** as well.
 
-    > [!NOTE]
-    > If web grounding is left on, the agent can answer from a web search instead of your custom connector. Turning it off forces the agent to use the Free Dictionary API tool for every query.
-
 1. Select **Save**.
 
 1. Close **Settings** using the **X** in the upper right-hand corner.

--- a/labs/mcs-tools/README.md
+++ b/labs/mcs-tools/README.md
@@ -360,9 +360,6 @@ Create a custom connector for the Free Dictionary API, add it as a tool in your 
 
 1. Turn off **Use information from the Web** as well.
 
-    > [!NOTE]
-    > If web grounding is left on, the agent can answer from a web search instead of your custom connector. Turning it off forces the agent to use the Free Dictionary API tool for every query.
-
 1. Select **Save**.
 
 1. Close **Settings** using the **X** in the upper right-hand corner.

--- a/labs/mcs-tools/README.md
+++ b/labs/mcs-tools/README.md
@@ -358,6 +358,11 @@ Create a custom connector for the Free Dictionary API, add it as a tool in your 
     > [!NOTE]
     > Disabling general knowledge make sure that only your custom connector API provides answers, not the underlying language model.
 
+1. Turn off **Use information from the Web** as well.
+
+    > [!NOTE]
+    > If web grounding is left on, the agent can answer from a web search instead of your custom connector. Turning it off forces the agent to use the Free Dictionary API tool for every query.
+
 1. Select **Save**.
 
 1. Close **Settings** using the **X** in the upper right-hand corner.
@@ -369,11 +374,11 @@ Create a custom connector for the Free Dictionary API, add it as a tool in your 
     ```
 
     ```
-    Where does it come from?
+    How about the word amazing?
     ```
 
     ```
-    How about the word amazing?
+    How do I pronounce the word "leverage" in English?
     ```
 
 1. Verify that the agent uses your custom connector tool to retrieve definitions, origins, and phonetic information from the Free Dictionary API.


### PR DESCRIPTION
## Summary
Fixes #462.

In UC #1, the test queries asked *"Where does it come from?"* as a follow-up. With **Use information from the Web** left ON, the agent answered the origin question via web search instead of the Dictionary API; with web grounding OFF it errored, because the Free Dictionary API doesn't return origin/phonetics for many words (e.g. *copilot*).

## Change (per issue's suggested fix)
- Add a step to turn off **Use information from the Web** (in addition to disabling general knowledge), so every query is answered by the Free Dictionary API connector.
- Replace the test questions with ones the API can actually answer:
  - What is the meaning of the word copilot?
  - How about the word amazing?
  - How do I pronounce the word "leverage" in English?

## Testing
Markdown-only content change to `labs/mcs-tools/README.md`.
