### PR TITLE
mcs-orchestration: fix UC#3 Dataverse MCP add flow (#465)

### DIFF
--- a/_labs/mcs-orchestration.md
+++ b/_labs/mcs-orchestration.md
@@ -676,9 +676,12 @@ You'll add two tools. In the new designer, adding a tool is **Add tool → pick 
 
 1. On the **Select a connection** step, pick your Dataverse connection. If you created one in an earlier lab it's already selected with a green check — just confirm it. Otherwise choose **Not connected → Create new connection → Create**, sign in / consent when the Entra popup appears. Then select **Next**.
 
-1. On **Review capabilities** (it lists the MCP server's actions — `read_query`, `search`, `create_table`, `update_record`, and so on), leave the **default selection** as-is and select **Confirm** to attach the server. This lab only ever exercises **`read_query`** (reading accounts and contacts) and **`search`** (schema discovery); the orchestrator won't call the write/delete actions unless a prompt explicitly asks it to.
+1. Once the **Microsoft Dataverse MCP Server** is added, open the tool and observe the list of the MCP server's actions (`read_query`, `search`, `create_table`, `update_record`, and so on). Leave the **default selection** as-is, but note that these can be turned on/off. This lab only ever exercises **`read_query`** (reading accounts and contacts) and **`search`** (schema discovery); the orchestrator won't call the write/delete actions unless a prompt explicitly asks it to.
 
-1. Select **Save** in the command bar. Your **Tools** list should now show **Get current weather** and **Microsoft Dataverse MCP Server**.
+    > [!NOTE]
+    > There is no separate **Review capabilities / Confirm** dialog when adding the connector — once you select **Add**, the tool is attached immediately.
+
+1. Close the **Tool** editing view. We now have **Get current weather** and **Microsoft Dataverse MCP Server** configured.
 
 #### Add knowledge to the agent
 

--- a/_labs/mcs-orchestration.md
+++ b/_labs/mcs-orchestration.md
@@ -678,9 +678,6 @@ You'll add two tools. In the new designer, adding a tool is **Add tool → pick 
 
 1. Once the **Microsoft Dataverse MCP Server** is added, open the tool and observe the list of the MCP server's actions (`read_query`, `search`, `create_table`, `update_record`, and so on). Leave the **default selection** as-is, but note that these can be turned on/off. This lab only ever exercises **`read_query`** (reading accounts and contacts) and **`search`** (schema discovery); the orchestrator won't call the write/delete actions unless a prompt explicitly asks it to.
 
-    > [!NOTE]
-    > There is no separate **Review capabilities / Confirm** dialog when adding the connector — once you select **Add**, the tool is attached immediately.
-
 1. Close the **Tool** editing view. We now have **Get current weather** and **Microsoft Dataverse MCP Server** configured.
 
 #### Add knowledge to the agent

--- a/labs/mcs-orchestration/README.md
+++ b/labs/mcs-orchestration/README.md
@@ -659,9 +659,12 @@ You'll add two tools. In the new designer, adding a tool is **Add tool → pick 
 
 1. On the **Select a connection** step, pick your Dataverse connection. If you created one in an earlier lab it's already selected with a green check — just confirm it. Otherwise choose **Not connected → Create new connection → Create**, sign in / consent when the Entra popup appears. Then select **Next**.
 
-1. On **Review capabilities** (it lists the MCP server's actions — `read_query`, `search`, `create_table`, `update_record`, and so on), leave the **default selection** as-is and select **Confirm** to attach the server. This lab only ever exercises **`read_query`** (reading accounts and contacts) and **`search`** (schema discovery); the orchestrator won't call the write/delete actions unless a prompt explicitly asks it to.
+1. Once the **Microsoft Dataverse MCP Server** is added, open the tool and observe the list of the MCP server's actions (`read_query`, `search`, `create_table`, `update_record`, and so on). Leave the **default selection** as-is, but note that these can be turned on/off. This lab only ever exercises **`read_query`** (reading accounts and contacts) and **`search`** (schema discovery); the orchestrator won't call the write/delete actions unless a prompt explicitly asks it to.
 
-1. Select **Save** in the command bar. Your **Tools** list should now show **Get current weather** and **Microsoft Dataverse MCP Server**.
+    > [!NOTE]
+    > There is no separate **Review capabilities / Confirm** dialog when adding the connector — once you select **Add**, the tool is attached immediately.
+
+1. Close the **Tool** editing view. We now have **Get current weather** and **Microsoft Dataverse MCP Server** configured.
 
 #### Add knowledge to the agent
 

--- a/labs/mcs-orchestration/README.md
+++ b/labs/mcs-orchestration/README.md
@@ -661,9 +661,6 @@ You'll add two tools. In the new designer, adding a tool is **Add tool → pick 
 
 1. Once the **Microsoft Dataverse MCP Server** is added, open the tool and observe the list of the MCP server's actions (`read_query`, `search`, `create_table`, `update_record`, and so on). Leave the **default selection** as-is, but note that these can be turned on/off. This lab only ever exercises **`read_query`** (reading accounts and contacts) and **`search`** (schema discovery); the orchestrator won't call the write/delete actions unless a prompt explicitly asks it to.
 
-    > [!NOTE]
-    > There is no separate **Review capabilities / Confirm** dialog when adding the connector — once you select **Add**, the tool is attached immediately.
-
 1. Close the **Tool** editing view. We now have **Get current weather** and **Microsoft Dataverse MCP Server** configured.
 
 #### Add knowledge to the agent


### PR DESCRIPTION
## Summary
Fixes #465.

UC #3 told learners that, after adding the **Microsoft Dataverse MCP Server**, a **Review capabilities** screen appears where you leave the default selection and select **Confirm** to attach the server. That screen does not appear — once you select **Add**, the tool is attached immediately.

## Change (per issue's suggested fix)
- Reword the step: once the server is added, open the tool and observe its actions (`read_query`, `search`, `create_table`, `update_record` …), leave the default selection as-is (note they can be toggled), and clarify the lab only exercises `read_query` and `search`.
- Add a follow-up step: close the Tool editing view — we now have **Get current weather** and **Microsoft Dataverse MCP Server** configured.

## Testing
Markdown-only content change to `labs/mcs-orchestration/README.md`.
