### PR TITLE
mcs-tools: sync UC2 pre-created agent change to _labs (site source)

### DIFF
--- a/_labs/mcs-tools.md
+++ b/_labs/mcs-tools.md
@@ -430,73 +430,40 @@ Build a Sales Commission Calculator using agent flows to implement deterministic
 
 **Summary of tasks**
 
-In this section, you'll learn how to create an agent flow with deterministic business logic, implement tier-based commission calculations using Power Fx, build a conversational topic that collects inputs and calls the flow, and test multiple scenarios to validate business rules.
+In this section, you'll explore a pre-created agent that uses an agent flow for deterministic business logic, see how tier-based commission calculations are implemented with Power Fx, and test multiple scenarios to validate the business rules.
 
 **Scenario:** Contoso Electronics has a sales team that needs instant visibility into their commission earnings. Commission calculations involve performance tiers with different percentage rates and product mix bonuses - rules that must always produce the same result for the same inputs. Agent flows are the ideal tool because they provide deterministic, rule-based processing rather than AI-generated responses.
 
 ### Objective
 
-Create an agent flow that calculates sales commissions using deterministic business rules, build a conversational topic to collect inputs, and test the complete workflow.
+Use a pre-created agent that calculates sales commissions with deterministic business rules, and test the complete workflow across multiple scenarios.
 
 ---
 
 ### Step-by-step instructions
 
-#### Create a New Agent
+#### Open the Pre-Created Agent
 
 1. Go to **Microsoft Copilot Studio** at <a href="https://copilotstudio.microsoft.com" target="_blank">copilotstudio.microsoft.com</a>.
 
 1. Make sure you are in the **New Copilot Studio experience** — look for the banner or toggle at the top and select **Try now** (or turn the **New experience** toggle ON).
 
-1. Select **Agents** on left navigation.
+1. Select **Agents** on left navigation, then open the pre-created **Sales Commission Assistant** agent.
 
-1. From the Agents list, select the down-arrow (chevron) next to **New Agent**, then choose **New classic agent**. In the **Name your agent** dialog, enter `Sales Commission Assistant` and select **Create**.
+    > [!NOTE]
+    > The **Sales Commission Assistant** agent has already been created and configured for you, and the **Calculate Sales Commission** agent flow is already connected as a tool. In a real implementation, you would create the agent and wire up the flow yourself — this lab provides them so you can focus on understanding how deterministic agent flows work.
 
-    > [!TIP]
-    > The agent creation may take 30-60 seconds. You'll see a loading indicator while your agent is being provisioned.
+1. (Optional) Review how the agent is configured so you understand what was set up for you:
 
-1. Select **Edit** in the **Details** section.
-
-1. Confirm the **Name** and add the **Description**:
-
-   - **Name:**
-     ```
-     Sales Commission Assistant
-     ```
-   - **Description:**
-     ```
-     Calculates sales commissions based on performance data
-     ```
-
-1. Select **Save** in the upper right corner of the **Details** section.
-
-1. On the **Overview** page, scroll down to the **Knowledge** section and turn off **Web Search**.
-
-1. Select **Edit** in the **Instructions** section and enter the following:
-
-    ```
-    When collecting information for a tool, always ask for one piece of information at a time.
-    ```
-
-1. Select **Save**.
+    - On the **Overview** page, the **Description** is set to `Calculates sales commissions based on performance data`, and **Web Search** is turned off in the **Knowledge** section.
+    - The **Instructions** section contains: `When collecting information for a tool, always ask for one piece of information at a time.`
+    - In the **Tools** section, the **Calculate Sales Commission** agent flow is connected.
 
     > [!NOTE]
     > Using instructions to explain how you want the agent to behave when collecting information is a good example of how Instructions should be used in agents. Instructions guide the agent's conversational behavior without requiring you to build explicit topics or flows for every interaction pattern.
 
-#### Add the Agent Flow
-
-1. In the top navigation panel, select **Tools**.
-
-1. Select **+ Add a tool**.
-
-1. In the filter list, select **Flow**.
-
-1. Select the pre-created **Calculate Sales Commission** flow from the results.
-
-1. Select **Add and configure**.
-
     > [!TIP]
-    > This flow has already been provisioned for you with the commission calculation logic, input parameters, and response configuration. In a real implementation, you would build the agent flow yourself using Power Fx expressions — the logic could be as complex as needed and could use all the capabilities of flow.
+    > The **Calculate Sales Commission** flow has already been provisioned for you with the commission calculation logic, input parameters, and response configuration. In a real implementation, you would build the agent flow yourself using Power Fx expressions — the logic could be as complex as needed and could use all the capabilities of flow.
 
 #### Test Your Commission Calculator
 


### PR DESCRIPTION
## Summary

Follow-up to #481. That PR updated `labs/mcs-tools/README.md`, but **the website renders from `_labs/mcs-tools.md`**, so the deployed UC2 lab still instructed participants to create the agent and connect the flow that are already provisioned for them.

This PR applies the identical UC2 change to `_labs/mcs-tools.md` so the published lab matches the README.

## Changes

- Replaced the **Create a New Agent** and **Add the Agent Flow** sections with a single **Open the Pre-Created Agent** section.
- Preserved the educational notes/tips and surfaced the agent's pre-set configuration (description, Web Search off, instructions, connected flow) as an optional review step.
- Updated the **Summary of tasks** and **Objective** to reflect using the pre-created agent rather than building it.
- No changes to the test scenarios or expected results.

Diff is identical to the one merged in #481, just applied to the `_labs/` copy that the site builds from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
