### PR TITLE
fix(mcs-tools): correct Dataverse table name in Use Case #3 agent instructions

### DIFF
--- a/_labs/mcs-tools.md
+++ b/_labs/mcs-tools.md
@@ -599,7 +599,7 @@ Create and configure a Copilot Agent with Dataverse MCP Server integration that 
     This agent will:
     Read accounts and contact information from the Account and Contact Tables in Dataverse using the Dataverse MCP Server.
     Update accounts and contact information from the Account and Contact Tables in Dataverse using the Dataverse MCP Server.
-    Create new accounts and contact information in the Account and Opportunity Tables in Dataverse using the Dataverse MCP Server.
+    Create new accounts and contact information in the Account and Contact Tables in Dataverse using the Dataverse MCP Server.
     Do not use outside knowledge. Only use the Dataverse MCP Tool to create, read, update and delete.
     ```
 1. Select **Save**

--- a/labs/mcs-tools/README.md
+++ b/labs/mcs-tools/README.md
@@ -582,7 +582,7 @@ Create and configure a Copilot Agent with Dataverse MCP Server integration that 
     This agent will:
     Read accounts and contact information from the Account and Contact Tables in Dataverse using the Dataverse MCP Server.
     Update accounts and contact information from the Account and Contact Tables in Dataverse using the Dataverse MCP Server.
-    Create new accounts and contact information in the Account and Opportunity Tables in Dataverse using the Dataverse MCP Server.
+    Create new accounts and contact information in the Account and Contact Tables in Dataverse using the Dataverse MCP Server.
     Do not use outside knowledge. Only use the Dataverse MCP Tool to create, read, update and delete.
     ```
 1. Select **Save**


### PR DESCRIPTION
### What

In `mcs-tools` Use Case #3, the instruction block the learner pastes into the agent tells it to create records in the **Account and Opportunity Tables**. This changes it to **Account and Contact Tables**.

```diff
  This agent will:
  Read accounts and contact information from the Account and Contact Tables in Dataverse using the Dataverse MCP Server.
  Update accounts and contact information from the Account and Contact Tables in Dataverse using the Dataverse MCP Server.
- Create new accounts and contact information in the Account and Opportunity Tables in Dataverse using the Dataverse MCP Server.
+ Create new accounts and contact information in the Account and Contact Tables in Dataverse using the Dataverse MCP Server.
  Do not use outside knowledge. Only use the Dataverse MCP Tool to create, read, update and delete.
```

### Why

The Read and Update lines directly above it both target the Account and Contact tables — only the Create line diverged. The same is true of the agent description, the objective, the summary of tasks, and every test prompt in the section (e.g. *"Who are the contacts for each account"*).

`Opportunity` appeared **exactly once** in the entire lab. The Opportunity table is never used by the exercise and is never seeded with sample data, so the pasted instruction pointed the agent at a table outside the lab's scope while omitting one it actually needs.

### Scope

Two files, one line each — the authored source and the rendered collection doc that the site builds from, per `docs/CONTENT_FEED.md`:

| File | Line |
| --- | --- |
| `labs/mcs-tools/README.md` | 585 |
| `_labs/mcs-tools.md` | 602 |

Verified locally with `scripts/check-lab-sync.js` — **Lab Doc Sync: OK**.

No instructions, steps, screenshots, or other labs are touched.

### Notes

Found during a documentation audit of the lab. Happy to open follow-ups for the other items it surfaced if useful — the most impactful being that Use Case #1 instructs the learner to turn the **New experience** toggle *off*, while the screenshot directly beneath it shows the New experience *on* with **New Agent ▾ → New classic agent**, which is also what Use Cases #2–#4 and four sibling labs (`mcs-multi-agent`, `mcs-alm`, `component-collections`, `autonomous-account-news`) instruct.
