### PR TITLE
mcs-instructions: add Save step before testing in UC3

### DIFF
--- a/_labs/mcs-instructions.md
+++ b/_labs/mcs-instructions.md
@@ -721,6 +721,8 @@ Add the workshop's sample policy document so the agent has a body of knowledge t
 
     ![Build tab with knowledge file and tools attached](images/uc3-build-tab-complete.png)
 
+1. Select **Save** in the command bar to save the agent with its new knowledge source.
+
 #### Test the Agentic Reasoning Loop
 
 Open the **Preview** tab. The New Orchestrator surfaces its work **inline in the Preview pane** — you'll see a **"Thought for N seconds"** line you can expand, a sentence of reasoning, and the name of each tool it calls before the final answer.

--- a/labs/mcs-instructions/README.md
+++ b/labs/mcs-instructions/README.md
@@ -706,6 +706,8 @@ Add the workshop's sample policy document so the agent has a body of knowledge t
 
     ![Build tab with knowledge file and tools attached](images/uc3-build-tab-complete.png)
 
+1. Select **Save** in the command bar to save the agent with its new knowledge source.
+
 #### Test the Agentic Reasoning Loop
 
 Open the **Preview** tab. The New Orchestrator surfaces its work **inline in the Preview pane** — you'll see a **"Thought for N seconds"** line you can expand, a sentence of reasoning, and the name of each tool it calls before the final answer.


### PR DESCRIPTION
## What

Small fix to **Use Case #3 (New Orchestrator – Agentic Reasoning Loop)** of the **Deep Dive: Instructions & Descriptions** lab.

- After confirming the knowledge file appears in the **Knowledge** section, added an explicit **Select Save** step before the **Test the Agentic Reasoning Loop** section.

## Why

Running the lab, the newly added knowledge source isn't reliably picked up in the test unless the agent is saved first. The instructions jumped straight from adding knowledge to testing.

## How

Inserted one numbered step; mirrored in `labs/mcs-instructions/README.md` and `_labs/mcs-instructions.md`.

## Impact / Testing

Docs-only. README and `_labs` page updated together (lab-doc-sync guard satisfied). No heading changes, so in-page TOC anchors are unaffected.
