### PR TITLE
Fix duplicate lab id 140 in _data/lab-config.yml (mcs-github-harness -> 145)

### DIFF
--- a/_data/lab-config.yml
+++ b/_data/lab-config.yml
@@ -61,7 +61,7 @@ lab_metadata:
     module: standard-harness
     section: core
     title: Standard Harness - Component Model
-  140:
+  145:
     difficulty: Advanced
     duration: 60
     id: mcs-github-harness
@@ -330,7 +330,7 @@ legacy_lab_orders:
   mcp-qualify-lead: 430
   mcs-alm: 280
   mcs-byom: 230
-  mcs-github-harness: 140
+  mcs-github-harness: 145
   mcs-governance: 195
   mcs-instructions: 293
   mcs-multi-agent: 250


### PR DESCRIPTION
## The bug

`lab_metadata` in `_data/lab-config.yml` assigns id **140** to two different labs:

- line 29 — `agent-builder-m365` (added 2026-08-10)
- line 64 — `mcs-github-harness` (added 2026-08-22, c4c1693a)

`legacy_lab_orders` mirrors the same collision.

## Why it matters

Two distinct failure modes, one loud and one silent:

1. **Tooling hard-fails.** Any YAML loader that rejects duplicate keys throws on this file. `powershell-yaml` raises `Exception calling "Load" with "1" argument(s): "Duplicate key 140"`, which takes down anything reading lab metadata.
2. **The site fails quietly.** Jekyll's loader is last-wins rather than fatal, so `mcs-github-harness` silently overwrites `agent-builder-m365`'s metadata — difficulty, duration, module, section and title. `mcs-github-harness` is Lab 8 in Bootcamp V3, so this is live.

## The fix

Renumber `mcs-github-harness` from 140 to **145**, in both `lab_metadata` and `legacy_lab_orders`. Two lines.

`mcs-github-harness` is the one that moves because every existing numeric `140` reference predates it and means `agent-builder-m365` — `lab_orders` for `agent-buildathon-1day`, `agent-buildathon-1month`, `mcs-in-a-day`, `mcs-in-a-day-v2` and `bootcamp`, plus the journey and section orders. All are left untouched and now resolve unambiguously.

Nothing referenced `mcs-github-harness` by numeric id: the slug-keyed orders (`bootcamp_lab_orders`, `agent_buildathon_*_lab_orders`) and the Bootcamp V3 agenda reference it by slug, so they are unaffected.

`145` was unused and continues the interleaved series this lab sits in — 105, 115, 125, **135** (`standard-harness-component-model`), **145** — which matches the guidance in `docs/NEW_LAB_CHECKLIST.md`: *"Pick a number adjacent to the labs you want to sit beside, and check what is already taken."*

## Verification

`Get-LabCatalog.ps1` goes from a hard YAML failure to exit 0, enumerating all **38** labs, with `agent-builder-m365` and `mcs-github-harness` both present under their own titles. No duplicate keys remain in `lab_metadata`.

## Unrelated, but spotted nearby

The file header reads *"AUTO-GENERATED - DO NOT EDIT / Generated by Generate-Labs.ps1 / Edit lab-config.yml in root instead"*, but there is no root `lab-config.yml` and no `Generate-Labs.ps1` in the repo. The header looks stale; left alone here to keep this PR to the one-line-per-site fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)