### PR TITLE
Fix lab asset links in the feed: PDFs and solution packages ship as relative paths

### DIFF
--- a/_labs/mcs-github-harness.md
+++ b/_labs/mcs-github-harness.md
@@ -117,7 +117,7 @@ In the final use case you build a second agent in a completely different industr
 
 #### MCP servers
 
-The four MCP servers ship with this lab as Dataverse solution packages under [`assets/mcp-servers`](assets/mcp-servers). They are what the agents actually call — without them, Use Cases #2, #3 and #4 have no data.
+The four MCP servers ship with this lab as Dataverse solution packages under [`assets/mcp-servers`](https://github.com/microsoft/mcs-labs/tree/main/labs/mcs-github-harness/assets/mcp-servers). They are what the agents actually call — without them, Use Cases #2, #3 and #4 have no data.
 
 | Solution package | Solution name in the environment | Tools it exposes |
 |------------------|----------------------------------|------------------|
@@ -161,7 +161,7 @@ In many delivery tenants the four solutions are already provisioned with the env
 
 Do this once per missing solution. Each import takes a minute or two.
 
-1. Download the `.zip` from [`assets/mcp-servers`](assets/mcp-servers). Use the **raw** file — GitHub's file view will not give you a usable archive, and a `.zip` that your browser has helpfully unpacked will not import.
+1. Download the `.zip` from [`assets/mcp-servers`](https://github.com/microsoft/mcs-labs/tree/main/labs/mcs-github-harness/assets/mcp-servers). Use the **raw** file — GitHub's file view will not give you a usable archive, and a `.zip` that your browser has helpfully unpacked will not import.
 
 1. In [make.powerapps.com](https://make.powerapps.com), confirm the environment picker, then select **Solutions → Import solution**.
 
@@ -179,7 +179,7 @@ Do this once per missing solution. Each import takes a minute or two.
 
 #### Knowledge documents
 
-The four PDFs ship with this lab under [`assets/knowledge-documents`](assets/knowledge-documents). Upload them into two SharePoint folders named exactly as below — the instructions reference those folder names, and Use Case #2 walks you to them.
+The four PDFs ship with this lab under [`assets/knowledge-documents`](https://github.com/microsoft/mcs-labs/tree/main/labs/mcs-github-harness/assets/knowledge-documents). Upload them into two SharePoint folders named exactly as below — the instructions reference those folder names, and Use Case #2 walks you to them.
 
 | Document | SharePoint folder | What the agent uses it for |
 |----------|-------------------|-----------------------------|

--- a/labs/mcs-github-harness/README.md
+++ b/labs/mcs-github-harness/README.md
@@ -102,7 +102,7 @@ In the final use case you build a second agent in a completely different industr
 
 #### MCP servers
 
-The four MCP servers ship with this lab as Dataverse solution packages under [`assets/mcp-servers`](assets/mcp-servers). They are what the agents actually call — without them, Use Cases #2, #3 and #4 have no data.
+The four MCP servers ship with this lab as Dataverse solution packages under [`assets/mcp-servers`](https://github.com/microsoft/mcs-labs/tree/main/labs/mcs-github-harness/assets/mcp-servers). They are what the agents actually call — without them, Use Cases #2, #3 and #4 have no data.
 
 | Solution package | Solution name in the environment | Tools it exposes |
 |------------------|----------------------------------|------------------|
@@ -146,7 +146,7 @@ In many delivery tenants the four solutions are already provisioned with the env
 
 Do this once per missing solution. Each import takes a minute or two.
 
-1. Download the `.zip` from [`assets/mcp-servers`](assets/mcp-servers). Use the **raw** file — GitHub's file view will not give you a usable archive, and a `.zip` that your browser has helpfully unpacked will not import.
+1. Download the `.zip` from [`assets/mcp-servers`](https://github.com/microsoft/mcs-labs/tree/main/labs/mcs-github-harness/assets/mcp-servers). Use the **raw** file — GitHub's file view will not give you a usable archive, and a `.zip` that your browser has helpfully unpacked will not import.
 
 1. In [make.powerapps.com](https://make.powerapps.com), confirm the environment picker, then select **Solutions → Import solution**.
 
@@ -164,7 +164,7 @@ Do this once per missing solution. Each import takes a minute or two.
 
 #### Knowledge documents
 
-The four PDFs ship with this lab under [`assets/knowledge-documents`](assets/knowledge-documents). Upload them into two SharePoint folders named exactly as below — the instructions reference those folder names, and Use Case #2 walks you to them.
+The four PDFs ship with this lab under [`assets/knowledge-documents`](https://github.com/microsoft/mcs-labs/tree/main/labs/mcs-github-harness/assets/knowledge-documents). Upload them into two SharePoint folders named exactly as below — the instructions reference those folder names, and Use Case #2 walks you to them.
 
 | Document | SharePoint folder | What the agent uses it for |
 |----------|-------------------|-----------------------------|

--- a/scripts/build-feed.js
+++ b/scripts/build-feed.js
@@ -73,24 +73,35 @@ function selectFeedItems(allItems, feedDef) {
 }
 module.exports.selectFeedItems = selectFeedItems;
 
+// Lab-owned directories whose relative refs are absolutized for the feed. Feed
+// consumers serve this markdown from their own origin, so a bare `images/x.png`
+// or `assets/guide.pdf` would resolve against their site and 404.
+const OWN_DIRS = ['images', 'assets'];
+
 function rewriteImages(markdown, baseUrl, collection, slug) {
   const base = `${baseUrl}/${collection}/${slug}`;
   const images = new Set();
-  const abs = (rel) => {
-    const url = `${base}/${rel}`;
-    images.add(url);
-    return url;
-  };
   let out = String(markdown == null ? '' : markdown);
-  // Markdown image/link refs: ](images/...) or ](./images/...)
-  // Matches any relative ref into the lab's images/ dir (images and linked assets); absolutized so consumers can fetch them.
-  out = out.replace(/\]\((?:\.\/)?images\/([^)\s]+)/g, (_m, p) => `](${abs('images/' + p)}`);
-  // HTML src="images/..." / src="./images/..."
-  out = out.replace(/src="(?:\.\/)?images\/([^"]+)"/g, (_m, p) => `src="${abs('images/' + p)}"`);
-  // HTML src='images/...'
-  out = out.replace(/src='(?:\.\/)?images\/([^']+)'/g, (_m, p) => `src='${abs('images/' + p)}'`);
+  for (const dir of OWN_DIRS) {
+    const abs = (rel) => {
+      const url = `${base}/${rel}`;
+      // Only images/ feeds the manifest: assets/ holds the PDFs and solution
+      // .zip files consumers link to rather than mirror, and `images` is part
+      // of the published feed schema.
+      if (dir === 'images') images.add(url);
+      return url;
+    };
+    // dir is a fixed literal from OWN_DIRS, so it needs no escaping here.
+    // Markdown image/link refs: ](<dir>/...) or ](./<dir>/...)
+    out = out.replace(new RegExp('\\]\\((?:\\./)?' + dir + '/([^)\\s]+)', 'g'), (_m, p) => `](${abs(dir + '/' + p)}`);
+    // HTML src="<dir>/..." / src="./<dir>/..."
+    out = out.replace(new RegExp('src="(?:\\./)?' + dir + '/([^"]+)"', 'g'), (_m, p) => `src="${abs(dir + '/' + p)}"`);
+    // HTML src='<dir>/...'
+    out = out.replace(new RegExp("src='(?:\\./)?" + dir + "/([^']+)'", 'g'), (_m, p) => `src='${abs(dir + '/' + p)}'`);
+  }
   return { markdown: out, images: [...images] };
 }
+
 module.exports.rewriteImages = rewriteImages;
 
 function contentHash(content) {

--- a/scripts/build-feed.test.js
+++ b/scripts/build-feed.test.js
@@ -127,6 +127,17 @@ test('rewriteImages: de-duplicates repeated images', () => {
   assert.equal(images.length, 1);
 });
 
+test('rewriteImages: absolutizes assets/ refs so feed consumers can fetch them', () => {
+  const md = '[pdf](assets/knowledge-documents/manual.pdf) [zip](./assets/mcp-servers/s.zip) <img src="assets/diagram.png">';
+  const { markdown, images } = feed.rewriteImages(md, 'https://x.test/mcs-labs', 'labs', 'demo');
+  assert.match(markdown, /\]\(https:\/\/x\.test\/mcs-labs\/labs\/demo\/assets\/knowledge-documents\/manual\.pdf\)/);
+  assert.match(markdown, /\]\(https:\/\/x\.test\/mcs-labs\/labs\/demo\/assets\/mcp-servers\/s\.zip\)/);
+  assert.match(markdown, /src="https:\/\/x\.test\/mcs-labs\/labs\/demo\/assets\/diagram\.png"/);
+  // assets/ stays out of the images manifest: consumers link to these, not mirror them
+  assert.deepEqual(images, []);
+});
+
+
 test('contentHash: deterministic, prefixed, and content-sensitive', () => {
   const h1 = feed.contentHash('hello');
   const h2 = feed.contentHash('hello');

--- a/scripts/consume-feed.js
+++ b/scripts/consume-feed.js
@@ -70,12 +70,19 @@ function mergeItems(taggedLists) {
 module.exports.mergeItems = mergeItems;
 
 function relativizeImages(markdown, ownBaseUrl, collection, slug) {
-  // Literal (non-regex) global replace of the own-origin images prefix. Using
+  // Literal (non-regex) global replace of the own-origin prefixes. Using
   // split/join avoids constructing a RegExp from a URL string (which trips
   // CodeQL's incomplete-hostname-regexp rule) and is exactly what we want here.
-  const absPrefix = `${ownBaseUrl}/${collection}/${slug}/images/`;
-  return String(markdown == null ? '' : markdown).split(absPrefix).join('images/');
+  // Mirrors OWN_DIRS in build-feed.js: whatever that absolutizes on the way out
+  // is made relative again for the origin that owns the lab.
+  let out = String(markdown == null ? '' : markdown);
+  for (const dir of ['images', 'assets']) {
+    const absPrefix = `${ownBaseUrl}/${collection}/${slug}/${dir}/`;
+    out = out.split(absPrefix).join(`${dir}/`);
+  }
+  return out;
 }
+
 module.exports.relativizeImages = relativizeImages;
 
 function renderFrontMatter(metadata) {

--- a/scripts/consume-feed.test.js
+++ b/scripts/consume-feed.test.js
@@ -81,6 +81,19 @@ test('relativizeImages: own-origin image URLs become relative, others untouched'
   );
 });
 
+test('relativizeImages: own-origin assets/ URLs become relative too', () => {
+  const base = 'https://microsoft.github.io/mcs-labs';
+  const md =
+    '[pdf](https://microsoft.github.io/mcs-labs/labs/demo/assets/knowledge-documents/manual.pdf) ' +
+    '[zip](https://microsoft.github.io/mcs-labs/labs/demo/assets/mcp-servers/s.zip) ' +
+    '[ext](https://partner.example.com/mcs-labs/labs/other/assets/c.pdf)';
+  const out = consume.relativizeImages(md, base, 'labs', 'demo');
+  assert.match(out, /\]\(assets\/knowledge-documents\/manual\.pdf\)/);
+  assert.match(out, /\]\(assets\/mcp-servers\/s\.zip\)/);
+  assert.match(out, /partner\.example\.com\/mcs-labs\/labs\/other\/assets\/c\.pdf/); // external untouched
+});
+
+
 const matter = require('gray-matter');
 
 test('renderFrontMatter: emits a YAML front-matter block', () => {
@@ -191,10 +204,12 @@ test('round-trip: self-only materialized bodies equal committed collection bodie
       const srcDir = path.join(process.cwd(), `_${collection}`);
       for (const f of fs.readdirSync(srcDir).filter((x) => x.endsWith('.md'))) {
         // `./images/` and `images/` are equivalent relative refs; the producer canonicalizes
-        // to `images/`, so normalize the committed side before comparing.
+        // to `images/`, so normalize the committed side before comparing. Same for `assets/`,
+        // which the producer absolutizes alongside images so feed consumers can fetch the
+        // PDFs and solution packages labs link to.
         const committed = matter(fs.readFileSync(path.join(srcDir, f), 'utf8')).content
-          .replace(/\]\(\.\/images\//g, '](images/')
-          .replace(/src=(["'])\.\/images\//g, 'src=$1images/');
+          .replace(/\]\(\.\/(images|assets)\//g, ']($1/')
+          .replace(/src=(["'])\.\/(images|assets)\//g, 'src=$1$2/');
         const materializedPath = path.join(out, `_${collection}`, f);
         assert.ok(fs.existsSync(materializedPath), `materialized ${collection}/${f} exists`);
         const materialized = matter(fs.readFileSync(materializedPath, 'utf8')).content;


### PR DESCRIPTION
## Why

The PDF links in the GitHub Copilot Harness lab's prerequisites are dead for anyone reading the lab through a syndicated feed. The files are in the repo and the links are spelled correctly — the feed just ships them as relative paths.

`rewriteImages()` in `scripts/build-feed.js` absolutized relative refs into a lab's `images/` directory but left `assets/` alone. Feed consumers serve that markdown from their own origin, so `assets/knowledge-documents/Aeris-3.2MW-Turbine-Maintenance-Manual-Excerpt.pdf` resolves against *their* site and 404s.

Confirmed against the live feed before the fix — `feed/items/labs/mcs-github-harness.json` carried 11 relative links while every image was absolute:

```
assets/knowledge-documents/Aeris-3.2MW-Turbine-Maintenance-Manual-Excerpt.pdf
assets/mcp-servers/NorthgateEnergyAssetTelemetryMCP_1_0_0_1.zip
...
https://microsoft.github.io/mcs-labs/labs/mcs-github-harness/images/prereq-solutions-list.png
```

The published site and the GitHub README were never broken: GitHub Pages 301-redirects `/labs/<slug>` to `/labs/<slug>/`, so relative refs resolve there. This only bites feed consumers.

## Scope

Six labs link into `assets/`, so all six are affected, not just this one:

| Lab | Relative `assets/` links |
| --- | --- |
| `standard-orchestrator` | 11 (these are **images** stored under `assets/`, so they render broken) |
| `mcs-github-harness` | 11 |
| `mcs-workflows` | 5 |
| `mcs-skills`, `mcs-orchestration` | 3 each |
| `m365-copilot-frontier-agents` | 2 |

## What changed

- **`build-feed.js`** — `rewriteImages()` iterates `OWN_DIRS` (`images`, `assets`) instead of hardcoding `images`.
- **`consume-feed.js`** — `relativizeImages()` mirrors it, so a lab round-tripping through its own origin comes back relative rather than absolute.
- **Round-trip test** — its existing `./images/` → `images/` normalization now covers `assets/` too. This is the same documented canonicalization, applied to one more directory; without it the `mbr-prep-sharepoint-agent` fixture (which writes `./assets/…`) fails.
- **Three directory links** in the harness lab pointed at `assets/` folders rather than files. Those 404 on GitHub Pages regardless of absolutization — there is no directory listing — so they now point at the GitHub tree view, which works from every surface.

The `images` manifest still lists only `images/`. `assets/` holds PDFs and solution packages that consumers link to rather than mirror, and `images` is part of the published feed schema.

## Verification

- `npm test` — 70/70 pass, including the round-trip test that materializes every committed lab and compares bodies.
- Rebuilt the feed locally: `mcs-github-harness` goes from 11 relative links to 0.
- All eight asset URLs return **200**, and both new GitHub tree URLs return **200**.

## Found but not fixed here

`_labs/mcs-skills.md` links to `../mcs-instructions/README.md` twice. That is correct in `labs/mcs-skills/README.md` (GitHub resolves it) but 404s on the published site, because `labs/*/README.md` is excluded from the Jekyll build. The fix is `../mcs-instructions/` in the `_labs` copy only, which makes the two sources legitimately diverge and trips the Lab Doc Sync warning — worth its own PR rather than smuggling it into this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
